### PR TITLE
Table cell trimming and escaping fixes

### DIFF
--- a/extensions/table.c
+++ b/extensions/table.c
@@ -194,7 +194,7 @@ static cmark_node *consume_until_pipe_or_eol(cmark_syntax_extension *self,
   return result;
 }
 
-static int ispunct(char c) {
+static int table_ispunct(char c) {
   return cmark_ispunct(c) && c != '|';
 }
 
@@ -208,7 +208,7 @@ static table_row *row_from_string(cmark_syntax_extension *self,
   cmark_strbuf_set(&temp_container->content, string, len);
 
   cmark_manage_extensions_special_characters(parser, true);
-  cmark_parser_set_backslash_ispunct_func(parser, ispunct);
+  cmark_parser_set_backslash_ispunct_func(parser, table_ispunct);
   cmark_parse_inlines(parser, temp_container, parser->refmap, parser->options);
   cmark_parser_set_backslash_ispunct_func(parser, NULL);
   cmark_manage_extensions_special_characters(parser, false);

--- a/extensions/table.c
+++ b/extensions/table.c
@@ -109,65 +109,67 @@ static cmark_node *consume_until_pipe_or_eol(cmark_syntax_extension *self,
   bool was_escape = false;
 
   while (*n) {
-    if ((*n)->type == CMARK_NODE_TEXT) {
+    cmark_node *node = *n;
+
+    if (node->type == CMARK_NODE_TEXT) {
       cmark_node *child = cmark_parser_add_child(
           parser, result, CMARK_NODE_TEXT, cmark_parser_get_offset(parser));
 
       if (was_escape) {
-        child->as.literal = cmark_chunk_dup(&(*n)->as.literal, *offset, 1);
+        child->as.literal = cmark_chunk_dup(&node->as.literal, *offset, 1);
         cmark_node_own(child);
         if (child->as.literal.data[0] == '|')
           cmark_node_free(child->prev);
         ++*offset;
-        if (*offset >= (*n)->as.literal.len) {
+        if (*offset >= node->as.literal.len) {
           *offset = 0;
-          *n = (*n)->next;
+          *n = node->next;
         }
         was_escape = false;
         continue;
       }
 
-      if (strncmp((const char *)(*n)->as.literal.data + *offset,
-            "\\",
-            (*n)->as.literal.len - *offset) == 0 &&
-          (*n)->next &&
-          (*n)->next->type == CMARK_NODE_TEXT) {
-        child->as.literal = cmark_chunk_dup(&(*n)->as.literal, *offset, 1);
+      const char *lit = (char *)node->as.literal.data + *offset;
+      const int lit_len = node->as.literal.len - *offset;
+
+      if (lit_len == 1 && lit[0] == '\\' &&
+          node->next &&
+          node->next->type == CMARK_NODE_TEXT) {
+        child->as.literal = cmark_chunk_dup(&node->as.literal, *offset, 1);
         cmark_node_own(child);
         was_escape = true;
-        *n = (*n)->next;
+        *n = node->next;
         continue;
       }
 
-      int pipe = find_unescaped_pipe(&(*n)->as.literal, *offset);
+      int pipe = find_unescaped_pipe(&node->as.literal, *offset);
       if (pipe == -1) {
-
-        child->as.literal = cmark_chunk_dup(&(*n)->as.literal, *offset,
-                                            (*n)->as.literal.len - *offset);
+        child->as.literal = cmark_chunk_dup(&node->as.literal, *offset,
+                                            node->as.literal.len - *offset);
         cmark_node_own(child);
       } else {
         pipe -= *offset;
 
         if (pipe) {
-          child->as.literal = cmark_chunk_dup(&(*n)->as.literal, *offset, pipe);
+          child->as.literal = cmark_chunk_dup(&node->as.literal, *offset, pipe);
           cmark_node_own(child);
         } else
           cmark_node_free(child);
 
         *offset += pipe + 1;
-        if (*offset >= (*n)->as.literal.len) {
+        if (*offset >= node->as.literal.len) {
           *offset = 0;
-          *n = (*n)->next;
+          *n = node->next;
         }
         break;
       }
 
-      *n = (*n)->next;
+      *n = node->next;
       *offset = 0;
     } else {
-      cmark_node *next = (*n)->next;
-      cmark_node_append_child(result, *n);
-      cmark_node_own(*n);
+      cmark_node *next = node->next;
+      cmark_node_append_child(result, node);
+      cmark_node_own(node);
       *n = next;
       *offset = 0;
     }

--- a/src/blocks.c
+++ b/src/blocks.c
@@ -1385,3 +1385,8 @@ void cmark_parser_advance_offset(cmark_parser *parser,
 
   S_advance_offset(parser, &input_chunk, count, columns != 0);
 }
+
+void cmark_parser_set_backslash_ispunct_func(cmark_parser *parser,
+                                             cmark_ispunct_func func) {
+  parser->backslash_ispunct = func;
+}

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -117,4 +117,20 @@ static CMARK_INLINE cmark_chunk cmark_chunk_buf_detach(cmark_strbuf *buf) {
   return c;
 }
 
+/* trim_new variants are to be used when the source chunk may or may not be
+ * allocated; forces a newly allocated chunk. */
+static CMARK_INLINE cmark_chunk cmark_chunk_ltrim_new(cmark_mem *mem, cmark_chunk *c) {
+  cmark_chunk r = cmark_chunk_dup(c, 0, c->len);
+  cmark_chunk_ltrim(&r);
+  cmark_chunk_to_cstr(mem, &r);
+  return r;
+}
+
+static CMARK_INLINE cmark_chunk cmark_chunk_rtrim_new(cmark_mem *mem, cmark_chunk *c) {
+  cmark_chunk r = cmark_chunk_dup(c, 0, c->len);
+  cmark_chunk_rtrim(&r);
+  cmark_chunk_to_cstr(mem, &r);
+  return r;
+}
+
 #endif

--- a/src/cmark_extension_api.h
+++ b/src/cmark_extension_api.h
@@ -245,6 +245,8 @@ typedef int (*cmark_html_filter_func) (cmark_syntax_extension *extension,
 typedef cmark_node *(*cmark_postprocess_func) (cmark_syntax_extension *extension,
                                                cmark_node *root);
 
+typedef int (*cmark_ispunct_func) (char c);
+
 /** Free a cmark_syntax_extension.
  */
 CMARK_EXPORT
@@ -348,6 +350,12 @@ void cmark_syntax_extension_set_private(cmark_syntax_extension *extension,
 CMARK_EXPORT
 void cmark_syntax_extension_set_postprocess_func(cmark_syntax_extension *extension,
                                                  cmark_postprocess_func func);
+
+/** See the documentation for 'cmark_syntax_extension'
+ */
+CMARK_EXPORT
+void cmark_parser_set_backslash_ispunct_func(cmark_parser *extension,
+                                             cmark_ispunct_func func);
 
 /** Return the index of the line currently being parsed, starting with 1.
  */

--- a/src/inlines.c
+++ b/src/inlines.c
@@ -695,11 +695,11 @@ static delimiter *S_insert_emph(subject *subj, delimiter *opener,
 }
 
 // Parse backslash-escape or just a backslash, returning an inline.
-static cmark_node *handle_backslash(subject *subj) {
+static cmark_node *handle_backslash(cmark_parser *parser, subject *subj) {
   advance(subj);
   unsigned char nextchar = peek_char(subj);
-  if (cmark_ispunct(
-          nextchar)) { // only ascii symbols and newline can be escaped
+  if ((parser->backslash_ispunct ? parser->backslash_ispunct : cmark_ispunct)(nextchar)) {
+    // only ascii symbols and newline can be escaped
     advance(subj);
     return make_str(subj->mem, cmark_chunk_dup(&subj->input, subj->pos - 1, 1));
   } else if (!is_eof(subj) && skip_line_end(subj)) {
@@ -1152,7 +1152,7 @@ static int parse_inline(cmark_parser *parser, subject *subj, cmark_node *parent,
     new_inl = handle_backticks(subj);
     break;
   case '\\':
-    new_inl = handle_backslash(subj);
+    new_inl = handle_backslash(parser, subj);
     break;
   case '&':
     new_inl = handle_entity(subj);

--- a/src/parser.h
+++ b/src/parser.h
@@ -47,6 +47,7 @@ struct cmark_parser {
   bool last_buffer_ended_with_cr;
   cmark_llist *syntax_extensions;
   cmark_llist *inline_syntax_extensions;
+  cmark_ispunct_func backslash_ispunct;
 };
 
 #ifdef __cplusplus

--- a/test/extensions.txt
+++ b/test/extensions.txt
@@ -19,18 +19,18 @@ Here's a well-formed table, doing everything it should.
 <table>
 <thead>
 <tr>
-<th> abc </th>
-<th> def </th>
+<th>abc</th>
+<th>def</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td> ghi </td>
-<td> jkl </td>
+<td>ghi</td>
+<td>jkl</td>
 </tr>
 <tr>
-<td> mno </td>
-<td> pqr </td>
+<td>mno</td>
+<td>pqr</td>
 </tr></tbody></table>
 ````````````````````````````````
 
@@ -52,18 +52,18 @@ Hi!
 <table>
 <thead>
 <tr>
-<th> <em>abc</em> </th>
-<th> セン </th>
+<th><em>abc</em></th>
+<th>セン</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td> 1. Block elements inside cells don't work. </td>
-<td> </td>
+<td>1. Block elements inside cells don't work.</td>
+<td></td>
 </tr>
 <tr>
-<td> But <strong><em>inline elements do</em></strong>. </td>
-<td> x </td>
+<td>But <strong><em>inline elements do</em></strong>.</td>
+<td>x</td>
 </tr></tbody></table>
 <p>Hi!</p>
 ````````````````````````````````
@@ -93,8 +93,8 @@ Here we demonstrate some edge cases about what is and isn't a table.
 <table>
 <thead>
 <tr>
-<th> Just enough table </th>
-<th> to be considered table </th>
+<th>Just enough table</th>
+<th>to be considered table</th>
 </tr>
 </thead>
 <tbody></tbody></table>
@@ -109,7 +109,7 @@ Here we demonstrate some edge cases about what is and isn't a table.
 <table>
 <thead>
 <tr>
-<th> xyz </th>
+<th>xyz</th>
 </tr>
 </thead>
 <tbody></tbody></table>
@@ -125,14 +125,14 @@ xyz | ghi
 <table>
 <thead>
 <tr>
-<th>abc </th>
-<th> def</th>
+<th>abc</th>
+<th>def</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td>xyz </td>
-<td> ghi</td>
+<td>xyz</td>
+<td>ghi</td>
 </tr></tbody></table>
 ````````````````````````````````
 
@@ -153,18 +153,18 @@ Hi!
 <table>
 <thead>
 <tr>
-<th> <em>abc</em> </th>
-<th> セン </th>
+<th><em>abc</em></th>
+<th>セン</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td> this row has a space at the end </td>
-<td> </td>
+<td>this row has a space at the end</td>
+<td></td>
 </tr>
 <tr>
-<td> But <strong><em>inline elements do</em></strong>. </td>
-<td> x </td>
+<td>But <strong><em>inline elements do</em></strong>.</td>
+<td>x</td>
 </tr></tbody></table>
 <p>Hi!</p>
 ````````````````````````````````
@@ -179,20 +179,20 @@ fff | ggg | hhh | iii | jjj
 <table>
 <thead>
 <tr>
-<th align="left">aaa </th>
-<th> bbb </th>
-<th align="center"> ccc </th>
-<th> ddd </th>
-<th align="right"> eee</th>
+<th align="left">aaa</th>
+<th>bbb</th>
+<th align="center">ccc</th>
+<th>ddd</th>
+<th align="right">eee</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td align="left">fff </td>
-<td> ggg </td>
-<td align="center"> hhh </td>
-<td> iii </td>
-<td align="right"> jjj</td>
+<td align="left">fff</td>
+<td>ggg</td>
+<td align="center">hhh</td>
+<td>iii</td>
+<td align="right">jjj</td>
 </tr></tbody></table>
 ````````````````````````````````
 
@@ -223,26 +223,26 @@ than the header are truncated.
 <table>
 <thead>
 <tr>
-<th> a </th>
-<th> b </th>
-<th> c </th>
+<th>a</th>
+<th>b</th>
+<th>c</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td> x</td>
+<td>x</td>
 <td></td>
 <td></td>
 </tr>
 <tr>
-<td> a </td>
-<td> b</td>
+<td>a</td>
+<td>b</td>
 <td></td>
 </tr>
 <tr>
-<td> 1 </td>
-<td> 2 </td>
-<td> 3 </td>
+<td>1</td>
+<td>2</td>
+<td>3</td>
 </tr></tbody></table>
 ````````````````````````````````
 
@@ -261,25 +261,25 @@ Tables with embedded pipes could be tricky.
 <table>
 <thead>
 <tr>
-<th> a </th>
-<th> b </th>
+<th>a</th>
+<th>b</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td> Escaped pipes are |okay|. </td>
-<td> Like | this. </td>
+<td>Escaped pipes are |okay|.</td>
+<td>Like | this.</td>
 </tr>
 <tr>
-<td> Within <code>|code| is okay</code> too. </td>
+<td>Within <code>|code| is okay</code> too.</td>
 <td></td>
 </tr>
 <tr>
-<td> <strong><em><code>c|</code></em></strong> | complex</td>
+<td><strong><em><code>c|</code></em></strong> | complex</td>
 <td></td>
 </tr>
 <tr>
-<td> don't <strong>_reparse_</strong></td>
+<td>don't <strong>_reparse_</strong></td>
 <td></td>
 </tr></tbody></table>
 ````````````````````````````````
@@ -295,7 +295,7 @@ This shouldn't assert.
 <table>
 <thead>
 <tr>
-<th> a </th>
+<th>a</th>
 </tr>
 </thead>
 <tbody></tbody></table>
@@ -315,24 +315,24 @@ This shouldn't assert.
 <table>
 <thead>
 <tr>
-<th> a </th>
+<th>a</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td> \ </td>
+<td>\</td>
 </tr>
 <tr>
-<td> \\ </td>
+<td>\\</td>
 </tr>
 <tr>
-<td> _ </td>
+<td>_</td>
 </tr>
 <tr>
-<td> | </td>
+<td>|</td>
 </tr>
 <tr>
-<td> a </td>
+<td>a</td>
 </tr></tbody></table>
 ````````````````````````````````
 
@@ -347,15 +347,15 @@ This shouldn't assert.
 <table>
 <thead>
 <tr>
-<th> a </th>
+<th>a</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td> <strong>hello</strong> </td>
+<td><strong>hello</strong></td>
 </tr>
 <tr>
-<td> ok <br> sure </td>
+<td>ok <br> sure</td>
 </tr></tbody></table>
 ````````````````````````````````
 
@@ -491,13 +491,13 @@ Autolink and tables.
 <table>
 <thead>
 <tr>
-<th> a </th>
-<th> b </th>
+<th>a</th>
+<th>b</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td> <a href="https://github.com">https://github.com</a> <a href="http://www.github.com">www.github.com</a> </td>
-<td> <a href="http://pokemon.com">http://pokemon.com</a> </td>
+<td><a href="https://github.com">https://github.com</a> <a href="http://www.github.com">www.github.com</a></td>
+<td><a href="http://pokemon.com">http://pokemon.com</a></td>
 </tr></tbody></table>
 ````````````````````````````````

--- a/test/extensions.txt
+++ b/test/extensions.txt
@@ -304,36 +304,57 @@ This shouldn't assert.
 ### Escaping
 
 ```````````````````````````````` example
-| a |
-| --- |
-| \\ |
-| \\\\ |
-| \_ |
-| \| |
-| \a |
+| a | b |
+| --- | --- |
+| \\ | `\\` |
+| \\\\ | `\\\\` |
+| \_ | `\_` |
+| \| | `\|` |
+| \a | `\a` |
+
+\\ `\\`
+
+\\\\ `\\\\`
+
+\_ `\_`
+
+\| `\|`
+
+\a `\a`
 .
 <table>
 <thead>
 <tr>
 <th>a</th>
+<th>b</th>
 </tr>
 </thead>
 <tbody>
 <tr>
 <td>\</td>
+<td><code>\\</code></td>
 </tr>
 <tr>
 <td>\\</td>
+<td><code>\\\\</code></td>
 </tr>
 <tr>
 <td>_</td>
+<td><code>\_</code></td>
 </tr>
 <tr>
 <td>|</td>
+<td><code>\|</code></td>
 </tr>
 <tr>
-<td>a</td>
+<td>\a</td>
+<td><code>\a</code></td>
 </tr></tbody></table>
+<p>\ <code>\\</code></p>
+<p>\\ <code>\\\\</code></p>
+<p>_ <code>\_</code></p>
+<p>| <code>\|</code></p>
+<p>\a <code>\a</code></p>
 ````````````````````````````````
 
 ### Embedded HTML


### PR DESCRIPTION
Fixes #1, fixes #3.

~~There's a refactor I might like to try upstreaming to `jgm/cmark`, too — bbe1880 changes most of the rendering API to use `cmark_chunk`s instead of `char *`. The length information in the chunk won't always be reflected in the result, due to an interaction with `cmark_chunk_rtrim`. See the commit message for more on that! Let me know if you'd like me to prepare an upstream PR and I'd be happy to.~~

/cc @vmg @jgm