### PR TITLE
Reference links in tables

### DIFF
--- a/test/extensions.txt
+++ b/test/extensions.txt
@@ -380,6 +380,30 @@ This shouldn't assert.
 </tr></tbody></table>
 ````````````````````````````````
 
+### Reference-style links
+
+```````````````````````````````` example
+Here's a link to [Freedom Planet 2][].
+
+| Here's a link to [Freedom Planet 2][] in a table header. |
+| --- |
+| Here's a link to [Freedom Planet 2][] in a table row. |
+
+[Freedom Planet 2]: http://www.freedomplanet2.com/
+.
+<p>Here's a link to <a href="http://www.freedomplanet2.com/">Freedom Planet 2</a>.</p>
+<table>
+<thead>
+<tr>
+<th>Here's a link to <a href="http://www.freedomplanet2.com/">Freedom Planet 2</a> in a table header.</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Here's a link to <a href="http://www.freedomplanet2.com/">Freedom Planet 2</a> in a table row.</td>
+</tr></tbody></table>
+````````````````````````````````
+
 
 ## Strikethroughs
 


### PR DESCRIPTION
Reference links are parsed in the inline parsing phase, which usually happens after all blocks have been parsed. Tables are block-level elements which parse their own inlines at block parse time, in order to determine how many cells a row has. The result is that no reference links which have been declared below the table are correctly resolved.

I'm changing this logic here to parse the inlines in a post-processing phase, caching the raw textual content to be parsed inside the `node_table_row` until that time. This way we correctly resolve reference links.

/cc @vmg