### PR TITLE
Fix empty table cell behaviour

### DIFF
--- a/extensions/table.c
+++ b/extensions/table.c
@@ -151,11 +151,8 @@ static cmark_node *consume_until_pipe_or_eol(cmark_syntax_extension *self,
       } else {
         pipe -= *offset;
 
-        if (pipe) {
-          child->as.literal = cmark_chunk_dup(&node->as.literal, *offset, pipe);
-          cmark_node_own(child);
-        } else
-          cmark_node_free(child);
+        child->as.literal = cmark_chunk_dup(&node->as.literal, *offset, pipe);
+        cmark_node_own(child);
 
         *offset += pipe + 1;
         if (*offset >= node->as.literal.len) {

--- a/extensions/table.c
+++ b/extensions/table.c
@@ -178,6 +178,8 @@ static cmark_node *consume_until_pipe_or_eol(cmark_syntax_extension *self,
     return NULL;
   }
 
+  cmark_consolidate_text_nodes(result);
+
   if (result->first_child->type == CMARK_NODE_TEXT) {
     cmark_chunk c = cmark_chunk_ltrim_new(parser->mem, &result->first_child->as.literal);
     cmark_chunk_free(parser->mem, &result->first_child->as.literal);
@@ -190,7 +192,6 @@ static cmark_node *consume_until_pipe_or_eol(cmark_syntax_extension *self,
     result->last_child->as.literal = c;
   }
 
-  cmark_consolidate_text_nodes(result);
   return result;
 }
 

--- a/test/extensions.txt
+++ b/test/extensions.txt
@@ -404,6 +404,29 @@ Here's a link to [Freedom Planet 2][].
 </tr></tbody></table>
 ````````````````````````````````
 
+### Sequential cells
+
+```````````````````````````````` example
+| a | b | c |
+| --- | --- | --- |
+| d || e |
+.
+<table>
+<thead>
+<tr>
+<th>a</th>
+<th>b</th>
+<th>c</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>d</td>
+<td></td>
+<td>e</td>
+</tr></tbody></table>
+````````````````````````````````
+
 
 ## Strikethroughs
 


### PR DESCRIPTION
Presently we fail to deal correctly with empty table cells when there's no space between the pipes delimiting the cell.