### PR TITLE
Reparse table cells within delimiters

### DIFF
--- a/src/inlines.c
+++ b/src/inlines.c
@@ -645,6 +645,8 @@ static delimiter *S_insert_emph(subject *subj, delimiter *opener,
   // create new emph or strong, and splice it in to our inlines
   // between the opener and closer
   emph = use_delims == 1 ? make_emph(subj->mem) : make_strong(subj->mem);
+  emph->start_column = opener_inl->start_column;
+  emph->end_column = closer_inl->end_column;
 
   tmp = opener_inl->next;
   while (tmp && tmp != closer_inl) {
@@ -1119,7 +1121,7 @@ static int parse_inline(cmark_parser *parser, subject *subj, cmark_node *parent,
   cmark_node *new_inl = NULL;
   cmark_chunk contents;
   unsigned char c;
-  bufsize_t endpos;
+  bufsize_t pos = subj->pos, endpos;
   c = peek_char(subj);
   if (c == 0) {
     return 0;
@@ -1189,6 +1191,8 @@ static int parse_inline(cmark_parser *parser, subject *subj, cmark_node *parent,
   }
   if (new_inl != NULL) {
     cmark_node_append_child(parent, new_inl);
+    new_inl->start_column = pos;
+    new_inl->end_column = subj->pos;
   }
 
   return 1;

--- a/src/iterator.c
+++ b/src/iterator.c
@@ -111,6 +111,7 @@ void cmark_consolidate_text_nodes(cmark_node *root) {
       while (tmp && tmp->type == CMARK_NODE_TEXT) {
         cmark_iter_next(iter); // advance pointer
         cmark_strbuf_put(&buf, tmp->as.literal.data, tmp->as.literal.len);
+        cur->end_column = tmp->end_column;
         next = tmp->next;
         cmark_node_free(tmp);
         tmp = next;

--- a/test/extensions.txt
+++ b/test/extensions.txt
@@ -427,6 +427,27 @@ Here's a link to [Freedom Planet 2][].
 </tr></tbody></table>
 ````````````````````````````````
 
+### Interaction with emphasis
+
+```````````````````````````````` example
+| a | b |
+| --- | --- |
+|***(a)***|
+.
+<table>
+<thead>
+<tr>
+<th>a</th>
+<th>b</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><em><strong>(a)</strong></em></td>
+<td></td>
+</tr></tbody></table>
+````````````````````````````````
+
 
 ## Strikethroughs
 


### PR DESCRIPTION
This is a massive hack and requires much refactoring. Also leaks a lot of memory. Fixes https://github.com/github/cmark/issues/18.

We reparse each table cell once we've worked out the bounds of the cells themselves. This is expensive and hacky.