### PR TITLE
Fix link order of cmark-gfm

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,10 +71,7 @@ include (GenerateExportHeader)
 add_executable(${PROGRAM} ${PROGRAM_SOURCES})
 add_compiler_export_flags()
 
-target_link_libraries(${PROGRAM} libcmark-gfm_static)
-
-add_dependencies(${PROGRAM} libcmark-gfmextensions_static)
-target_link_libraries(${PROGRAM} libcmark-gfmextensions_static)
+target_link_libraries(${PROGRAM} libcmark-gfmextensions_static libcmark-gfm_static)
 
 # Disable the PUBLIC declarations when compiling the executable:
 set_target_properties(${PROGRAM} PROPERTIES


### PR DESCRIPTION
I had the following link problems with the Debug build on Linux:

```
../extensions/libcmark-gfmextensions.a(table.c.o): In function `try_opening_table_header':
/home/stefan/cmark/extensions/table.c:163: undefined reference to `cmark_arena_push'
/home/stefan/cmark/extensions/table.c:170: undefined reference to `cmark_arena_pop'
/home/stefan/cmark/extensions/table.c:183: undefined reference to `cmark_arena_pop'
/home/stefan/cmark/extensions/table.c:187: undefined reference to `cmark_arena_pop'
../extensions/libcmark-gfmextensions.a(table.c.o): In function `matches':
/home/stefan/cmark/extensions/table.c:321: undefined reference to `cmark_arena_push'
/home/stefan/cmark/extensions/table.c:328: undefined reference to `cmark_arena_pop'
collect2: error: ld returned 1 exit status
```

To fix that I changed to order of the libraries that are linked to cmark-gfm, such that the extensions occur first. This should work as long as there are no circular dependencies between the extensions library and mark (which would be bad anyway).

I also removed the add_dependencies line which is unnecessary from my point of view.