### PR TITLE
Don't scan past an EOL

### DIFF
--- a/src/scanners.re
+++ b/src/scanners.re
@@ -128,7 +128,7 @@ bufsize_t _scan_liberal_html_tag(const unsigned char *p)
   const unsigned char *marker = NULL;
   const unsigned char *start = p;
 /*!re2c
-  .+ [>] { return (bufsize_t)(p - start); }
+  [^\x00]+ [>] { return (bufsize_t)(p - start); }
   * { return 0; }
 */
 }
@@ -167,7 +167,7 @@ bufsize_t _scan_html_block_end_1(const unsigned char *p)
   const unsigned char *marker = NULL;
   const unsigned char *start = p;
 /*!re2c
-  .* [<] [/] ('script'|'pre'|'style') [>] { return (bufsize_t)(p - start); }
+  [^\x00]* [<] [/] ('script'|'pre'|'style') [>] { return (bufsize_t)(p - start); }
   * { return 0; }
 */
 }
@@ -178,7 +178,7 @@ bufsize_t _scan_html_block_end_2(const unsigned char *p)
   const unsigned char *marker = NULL;
   const unsigned char *start = p;
 /*!re2c
-  .* '-->' { return (bufsize_t)(p - start); }
+  [^\x00]* '-->' { return (bufsize_t)(p - start); }
   * { return 0; }
 */
 }
@@ -189,7 +189,7 @@ bufsize_t _scan_html_block_end_3(const unsigned char *p)
   const unsigned char *marker = NULL;
   const unsigned char *start = p;
 /*!re2c
-  .* '?>' { return (bufsize_t)(p - start); }
+  [^\x00]* '?>' { return (bufsize_t)(p - start); }
   * { return 0; }
 */
 }
@@ -200,7 +200,7 @@ bufsize_t _scan_html_block_end_4(const unsigned char *p)
   const unsigned char *marker = NULL;
   const unsigned char *start = p;
 /*!re2c
-  .* '>' { return (bufsize_t)(p - start); }
+  [^\x00]* '>' { return (bufsize_t)(p - start); }
   * { return 0; }
 */
 }
@@ -211,7 +211,7 @@ bufsize_t _scan_html_block_end_5(const unsigned char *p)
   const unsigned char *marker = NULL;
   const unsigned char *start = p;
 /*!re2c
-  .* ']]>' { return (bufsize_t)(p - start); }
+  [^\x00]* ']]>' { return (bufsize_t)(p - start); }
   * { return 0; }
 */
 }


### PR DESCRIPTION
re2c-generated scanners don't care about/treat specially NUL bytes in their input, meaning we can run off the end of the buffer like this, causing crashes or other unexpected (potentially dangerous) behaviour.

/cc @jgm heads up, this may affect upstream too. I'll prepare a PR once I'm sure this is a conclusive fix for what we're seeing.