### PR TITLE
Avoid memcpy'ing NULL pointers

### DIFF
--- a/src/inlines.c
+++ b/src/inlines.c
@@ -106,7 +106,8 @@ static cmark_chunk chunk_clone(cmark_mem *mem, cmark_chunk *src) {
   c.len = len;
   c.data = (unsigned char *)mem->calloc(len + 1, 1);
   c.alloc = 1;
-  memcpy(c.data, src->data, len);
+  if (len)
+    memcpy(c.data, src->data, len);
   c.data[len] = '\0';
 
   return c;


### PR DESCRIPTION
A UBSAN warning can be triggered because the link title is an empty string:

  src/inlines.c:113:20: runtime error: null pointer passed as argument 2, which is declared to never be null

which can be triggered by:
```
[f]:_
[f]
```

The length of the memcpy is zero so the NULL pointer is not dereferenced but it
is still undefined behaviour.