### PR TITLE
Allocate memory from arena with correct alignment

### DIFF
--- a/src/arena.c
+++ b/src/arena.c
@@ -62,6 +62,12 @@ static void *arena_calloc(size_t nmem, size_t size) {
     init_arena();
 
   size_t sz = nmem * size + sizeof(size_t);
+
+  // Round allocation sizes to largest integer size to
+  // ensure returned memory is correctly aligned
+  const size_t align = sizeof(size_t) - 1;
+  sz = (sz + align) & ~align;
+
   if (sz > A->sz) {
     A->prev = alloc_arena_chunk(sz, A->prev);
     return (uint8_t *) A->prev->ptr + sizeof(size_t);
@@ -71,8 +77,7 @@ static void *arena_calloc(size_t nmem, size_t size) {
   }
   void *ptr = (uint8_t *) A->ptr + A->used;
   A->used += sz;
-  size_t new_sz = nmem * size;
-  memcpy(ptr, &new_sz, sizeof(new_sz));
+  *((size_t *) ptr) = sz - sizeof(size_t);
   return (uint8_t *) ptr + sizeof(size_t);
 }
 


### PR DESCRIPTION
The arena allocator does not align memory when allocating blocks which can
trigger undefined behaviour. From UBSAN:

  src/inlines.c:83:30: runtime error: member access within misaligned address
  0x00010b30ede3 for type 'cmark_node' (aka 'struct cmark_node'), which requires
  8 byte alignment

This could cause a crash if the unaligned memory is passed to functions using
instructions which require alignment, such as SSE. Round-up the size of the
allocation to a multiple of `sizeof(size_t)` to ensure every allocation is
correctly aligned.