### PR TITLE
Case-insensitive tagfilter

### DIFF
--- a/extensions/tagfilter.c
+++ b/extensions/tagfilter.c
@@ -1,5 +1,6 @@
 #include "tagfilter.h"
 #include <parser.h>
+#include <ctype.h>
 
 static const char *blacklist[] = {
     "title",   "textarea", "style",  "xmp",       "iframe",
@@ -23,7 +24,7 @@ static int is_tag(const unsigned char *tag_data, size_t tag_size,
     if (*tagname == 0)
       break;
 
-    if (tag_data[i] != *tagname)
+    if (tolower(tag_data[i]) != *tagname)
       return 0;
   }
 

--- a/test/spec.txt
+++ b/test/spec.txt
@@ -9285,12 +9285,12 @@ All other HTML tags are left untouched.
 <strong> <title> <style> <em>
 
 <blockquote>
-  <xmp> is disallowed.
+  <xmp> is disallowed.  <XMP> is also disallowed.
 </blockquote>
 .
 <p><strong> &lt;title> &lt;style> <em></p>
 <blockquote>
-  &lt;xmp> is disallowed.
+  &lt;xmp> is disallowed.  &lt;XMP> is also disallowed.
 </blockquote>
 ````````````````````````````````
 


### PR DESCRIPTION
See #42.

(This doesn't affect github.com because our HTML sanitization catches it, but this means the tags get rendered out as plaintext instead, consistent with lowercase tags.)