### PR TITLE
> 32 nested balanced parens in a link is bananas

### DIFF
--- a/src/inlines.c
+++ b/src/inlines.c
@@ -871,6 +871,8 @@ static bufsize_t manual_scan_link_url(cmark_chunk *input, bufsize_t offset) {
       else if (input->data[i] == '(') {
         ++nb_p;
         ++i;
+        if (nb_p > 32)
+          return -1;
       } else if (input->data[i] == ')') {
         if (nb_p == 0)
           break;


### PR DESCRIPTION
Fixes https://github.com/jgm/cmark/issues/214.

/cc @mity @vmg