### PR TITLE
Period in email must precede alnum

### DIFF
--- a/extensions/autolink.c
+++ b/extensions/autolink.c
@@ -319,7 +319,7 @@ static void postprocess_text(cmark_parser *parser, cmark_node *text, int offset)
 
     if (c == '@')
       nb++;
-    else if (c == '.' && link_end < size - 1)
+    else if (c == '.' && link_end < size - 1 && cmark_isalnum(data[link_end + 1]))
       np++;
     else if (c != '-' && c != '_')
       break;

--- a/test/extensions.txt
+++ b/test/extensions.txt
@@ -523,6 +523,19 @@ This shouldn't crash everything: (_A_@_.A
 <IGNORE>
 ````````````````````````````````
 
+```````````````````````````````` example
+These should not link:
+
+* @a.b.c@. x
+* n@.  b
+.
+<p>These should not link:</p>
+<ul>
+<li>@a.b.c@. x</li>
+<li>n@.  b</li>
+</ul>
+````````````````````````````````
+
 ## HTML tag filter
 
 


### PR DESCRIPTION
The code used to make sense this way when we weren't doing this in a post-processing step.

Fixes #57.