### PR TITLE
use style="text-align: ..." instead of align in tables

### DIFF
--- a/extensions/table.c
+++ b/extensions/table.c
@@ -611,9 +611,9 @@ static void html_render(cmark_syntax_extension *extension,
           break;
 
       switch (alignments[i]) {
-      case 'l': cmark_strbuf_puts(html, " align=\"left\""); break;
-      case 'c': cmark_strbuf_puts(html, " align=\"center\""); break;
-      case 'r': cmark_strbuf_puts(html, " align=\"right\""); break;
+      case 'l': cmark_strbuf_puts(html, " style=\"text-align: left\""); break;
+      case 'c': cmark_strbuf_puts(html, " style=\"text-align: center\""); break;
+      case 'r': cmark_strbuf_puts(html, " style=\"text-align: right\""); break;
       }
 
       cmark_html_render_sourcepos(node, html, options);

--- a/test/extensions.txt
+++ b/test/extensions.txt
@@ -176,20 +176,20 @@ fff | ggg | hhh | iii | jjj
 <table>
 <thead>
 <tr>
-<th align="left">aaa</th>
+<th style="text-align: left">aaa</th>
 <th>bbb</th>
-<th align="center">ccc</th>
+<th style="text-align: center">ccc</th>
 <th>ddd</th>
-<th align="right">eee</th>
+<th style="text-align: right">eee</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td align="left">fff</td>
+<td style="text-align: left">fff</td>
 <td>ggg</td>
-<td align="center">hhh</td>
+<td style="text-align: center">hhh</td>
 <td>iii</td>
-<td align="right">jjj</td>
+<td style="text-align: right">jjj</td>
 </tr></tbody></table>
 ````````````````````````````````
 

--- a/test/spec.txt
+++ b/test/spec.txt
@@ -3270,14 +3270,14 @@ bar | baz
 <table>
 <thead>
 <tr>
-<th align="center">abc</th>
-<th align="right">defghi</th>
+<th style="text-align: center">abc</th>
+<th style="text-align: right">defghi</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td align="center">bar</td>
-<td align="right">baz</td>
+<td style="text-align: center">bar</td>
+<td style="text-align: right">baz</td>
 </tr></tbody></table>
 ````````````````````````````````
 


### PR DESCRIPTION
* ReactJS does not support `align` attributes
  * https://reactjs.org/docs/dom-elements.html
* `align` attributes are obsolete in HTML5
  * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td
