### PR TITLE
add CMARK_OPT_TABLE_PREFER_STYLE_ATTRIBUTES to align table cells with style attributes

### DIFF
--- a/extensions/table.c
+++ b/extensions/table.c
@@ -542,6 +542,18 @@ static void man_render(cmark_syntax_extension *extension,
   }
 }
 
+static void html_table_add_align(cmark_strbuf* html, const char* align, int options) {
+  if (options & CMARK_OPT_TABLE_PREFER_STYLE_ATTRIBUTES) {
+    cmark_strbuf_puts(html, " style=\"text-align: ");
+    cmark_strbuf_puts(html, align);
+    cmark_strbuf_puts(html, "\"");
+  } else {
+    cmark_strbuf_puts(html, " align=\"");
+    cmark_strbuf_puts(html, align);
+    cmark_strbuf_puts(html, "\"");
+  }
+}
+
 struct html_table_state {
   unsigned need_closing_table_body : 1;
   unsigned in_table_header : 1;
@@ -611,9 +623,9 @@ static void html_render(cmark_syntax_extension *extension,
           break;
 
       switch (alignments[i]) {
-      case 'l': cmark_strbuf_puts(html, " align=\"left\""); break;
-      case 'c': cmark_strbuf_puts(html, " align=\"center\""); break;
-      case 'r': cmark_strbuf_puts(html, " align=\"right\""); break;
+      case 'l': html_table_add_align(html, "left", options); break;
+      case 'c': html_table_add_align(html, "center", options); break;
+      case 'r': html_table_add_align(html, "right", options); break;
       }
 
       cmark_html_render_sourcepos(node, html, options);

--- a/man/man3/cmark-gfm.3
+++ b/man/man3/cmark-gfm.3
@@ -1,4 +1,4 @@
-.TH cmark-gfm 3 "January 25, 2018" "LOCAL" "Library Functions Manual"
+.TH cmark-gfm 3 "February 20, 2018" "LOCAL" "Library Functions Manual"
 .SH
 NAME
 .PP
@@ -969,6 +969,18 @@ Parse footnotes.
 .PP
 Only parse strikethroughs if surrounded by exactly 2 tildes. Gives some
 compatibility with redcarpet.
+
+.PP
+.nf
+\fC
+.RS 0n
+#define CMARK_OPT_TABLE_PREFER_STYLE_ATTRIBUTES (1 << 15)
+.RE
+\f[]
+.fi
+
+.PP
+Use style attributes to align table cells instead of align attributes.
 
 .SS
 Version information

--- a/src/cmark.h
+++ b/src/cmark.h
@@ -729,6 +729,10 @@ char *cmark_render_latex_with_mem(cmark_node *root, int options, int width, cmar
  */
 #define CMARK_OPT_STRIKETHROUGH_DOUBLE_TILDE (1 << 14)
 
+/** Use style attributes to align table cells instead of align attributes.
+ */
+#define CMARK_OPT_TABLE_PREFER_STYLE_ATTRIBUTES (1 << 15)
+
 /**
  * ## Version information
  */

--- a/src/main.c
+++ b/src/main.c
@@ -46,6 +46,8 @@ void print_usage() {
   printf("  --list-extensions              List available extensions and quit\n");
   printf("  --strikethrough-double-tilde   Only parse strikethrough (if enabled)\n");
   printf("                                 with two tildes\n");
+  printf("  --table-prefer-style-attributes Use style attributes to align table cells\n"
+         "                                  instead of align attributes.\n");
   printf("  --help, -h       Print usage information\n");
   printf("  --version        Print version\n");
 }
@@ -131,6 +133,8 @@ int main(int argc, char *argv[]) {
     } else if (strcmp(argv[i], "--list-extensions") == 0) {
       print_extensions();
       goto success;
+    } else if (strcmp(argv[i], "--table-prefer-style-attributes") == 0) {
+      options |= CMARK_OPT_TABLE_PREFER_STYLE_ATTRIBUTES;
     } else if (strcmp(argv[i], "--strikethrough-double-tilde") == 0) {
       options |= CMARK_OPT_STRIKETHROUGH_DOUBLE_TILDE;
     } else if (strcmp(argv[i], "--sourcepos") == 0) {


### PR DESCRIPTION
Add a new option to use `style` in table cells instead of obsolete `align`; this option is helpful to integrate this library with some JS frameworks (e.g. ReactJS) that ignore `align`.

BTW How can I write unit tests for these works?

I test it with command line:

```sh
echo '| abc | defghi |' > t.md
echo ':-: | -----------:' >> t.md
echo 'bar | baz' >> t.md
./build/src/cmark-gfm  -e table --table-prefer-style-attributes t.md
```

output:

```html
<table>
<thead>
<tr>
<th style="text-align: center">abc</th>
<th style="text-align: right">defghi</th>
</tr>
</thead>
<tbody>
<tr>
<td style="text-align: center">bar</td>
<td style="text-align: right">baz</td>
</tr></tbody></table>
```

(amend https://github.com/github/cmark/pull/85)

