### PR TITLE
Syntax extension API: allow to create extension nodes

### DIFF
--- a/src/cmark-gfm-extension_api.h
+++ b/src/cmark-gfm-extension_api.h
@@ -106,8 +106,6 @@ typedef struct cmark_plugin cmark_plugin;
  * with 'cmark_syntax_extension_set_private',
  * and optionally define a free function for this data.
  */
-typedef struct cmark_syntax_extension cmark_syntax_extension;
-
 typedef struct subject cmark_inline_parser;
 
 /** Exposed raw for now */
@@ -254,6 +252,10 @@ typedef cmark_node *(*cmark_postprocess_func) (cmark_syntax_extension *extension
 
 typedef int (*cmark_ispunct_func) (char c);
 
+typedef void (*cmark_opaque_alloc_func) (cmark_syntax_extension *extension,
+                                         cmark_mem *mem,
+                                         cmark_node *node);
+
 typedef void (*cmark_opaque_free_func) (cmark_syntax_extension *extension,
                                         cmark_mem *mem,
                                         cmark_node *node);
@@ -381,6 +383,12 @@ void *cmark_syntax_extension_get_private(cmark_syntax_extension *extension);
 CMARK_GFM_EXPORT
 void cmark_syntax_extension_set_postprocess_func(cmark_syntax_extension *extension,
                                                  cmark_postprocess_func func);
+
+/** See the documentation for 'cmark_syntax_extension'
+ */
+CMARK_GFM_EXPORT
+void cmark_syntax_extension_set_opaque_alloc_func(cmark_syntax_extension *extension,
+                                                  cmark_opaque_alloc_func func);
 
 /** See the documentation for 'cmark_syntax_extension'
  */

--- a/src/cmark-gfm.h
+++ b/src/cmark-gfm.h
@@ -92,6 +92,7 @@ typedef enum {
 typedef struct cmark_node cmark_node;
 typedef struct cmark_parser cmark_parser;
 typedef struct cmark_iter cmark_iter;
+typedef struct cmark_syntax_extension cmark_syntax_extension;
 
 /**
  * ## Custom memory allocator support
@@ -186,6 +187,13 @@ CMARK_GFM_EXPORT cmark_node *cmark_node_new(cmark_node_type type);
  */
 CMARK_GFM_EXPORT cmark_node *cmark_node_new_with_mem(cmark_node_type type,
                                                  cmark_mem *mem);
+
+CMARK_GFM_EXPORT cmark_node *cmark_node_new_with_ext(cmark_node_type type,
+                                                cmark_syntax_extension *extension);
+
+CMARK_GFM_EXPORT cmark_node *cmark_node_new_with_mem_and_ext(cmark_node_type type,
+                                                cmark_mem *mem,
+                                                cmark_syntax_extension *extension);
 
 /** Frees the memory allocated for a node and any children.
  */

--- a/src/syntax_extension.c
+++ b/src/syntax_extension.c
@@ -128,6 +128,11 @@ void *cmark_syntax_extension_get_private(cmark_syntax_extension *extension) {
     return extension->priv;
 }
 
+void cmark_syntax_extension_set_opaque_alloc_func(cmark_syntax_extension *extension,
+                                                  cmark_opaque_alloc_func func) {
+  extension->opaque_alloc_func = func;
+}
+
 void cmark_syntax_extension_set_opaque_free_func(cmark_syntax_extension *extension,
                                                  cmark_opaque_free_func func) {
   extension->opaque_free_func = func;

--- a/src/syntax_extension.h
+++ b/src/syntax_extension.h
@@ -25,6 +25,7 @@ struct cmark_syntax_extension {
   cmark_html_render_func          html_render_func;
   cmark_html_filter_func          html_filter_func;
   cmark_postprocess_func          postprocess_func;
+  cmark_opaque_alloc_func         opaque_alloc_func;
   cmark_opaque_free_func          opaque_free_func;
   cmark_commonmark_escape_func    commonmark_escape_func;
 };


### PR DESCRIPTION
Currently it is not possible to create nodes defined by syntax extensions using the C API if they use the `opaque` field (e.g. the `"table"` extension) because there is no way to correctly allocate this field without exposing the details of the syntax extension in question. Concretely this means that it is not possible to programmatically create documents containing syntax extension nodes.

This PR adds a field `opaque_alloc_func`to the `cmark_syntax_extension` struct of type
```c
typedef void (*cmark_opaque_alloc_func) (cmark_syntax_extension *extension,
                                         cmark_mem *mem,
                                         cmark_node *node);
```
which is supposed to fill the `opaque` field of a `cmark_node` in those syntax extensions that need it.

Since this field must be allocated when creating the `cmark_node`, the function `cmark_node_new` has been extended to take a `cmark_syntax_extension *` argument:
```c
CMARK_EXPORT cmark_node *cmark_node_new(cmark_node_type type,
                                        cmark_syntax_extension *extension);
```
(a new function could be introduced for this purpose to avoid changing the signature of `cmark_node_new`.)

What do you think? Do you find this approach reasonable? Opinions welcome!

Thanks!