### PR TITLE
Remove square brackets when rendering HTML for footnotes

### DIFF
--- a/src/html.c
+++ b/src/html.c
@@ -406,9 +406,9 @@ static int S_render_node(cmark_html_renderer *renderer, cmark_node *node,
       cmark_strbuf_put(html, node->as.literal.data, node->as.literal.len);
       cmark_strbuf_puts(html, "\" id=\"fnref");
       cmark_strbuf_put(html, node->as.literal.data, node->as.literal.len);
-      cmark_strbuf_puts(html, "\">[");
+      cmark_strbuf_puts(html, "\">");
       cmark_strbuf_put(html, node->as.literal.data, node->as.literal.len);
-      cmark_strbuf_puts(html, "]</a></sup>");
+      cmark_strbuf_puts(html, "</a></sup>");
     }
     break;
 

--- a/test/extensions.txt
+++ b/test/extensions.txt
@@ -609,9 +609,9 @@ Hi!
 
 [^unused]: This is unused.
 .
-<p>This is some text!<sup class="footnote-ref"><a href="#fn1" id="fnref1">[1]</a></sup>. Other text.<sup class="footnote-ref"><a href="#fn2" id="fnref2">[2]</a></sup>.</p>
-<p>Here's a thing<sup class="footnote-ref"><a href="#fn3" id="fnref3">[3]</a></sup>.</p>
-<p>And another thing<sup class="footnote-ref"><a href="#fn4" id="fnref4">[4]</a></sup>.</p>
+<p>This is some text!<sup class="footnote-ref"><a href="#fn1" id="fnref1">1</a></sup>. Other text.<sup class="footnote-ref"><a href="#fn2" id="fnref2">2</a></sup>.</p>
+<p>Here's a thing<sup class="footnote-ref"><a href="#fn3" id="fnref3">3</a></sup>.</p>
+<p>And another thing<sup class="footnote-ref"><a href="#fn4" id="fnref4">4</a></sup>.</p>
 <p>This doesn't have a referent[^nope].</p>
 <p>Hi!</p>
 <section class="footnotes">


### PR DESCRIPTION
As [discussed in a PR for CommonMarker](https://github.com/gjtorikian/commonmarker/pull/69), Cmark currently renders square brackets around footnotes. This fixes that.