### PR TITLE
Expose `cmark_node_type CMARK_NODE_TABLE` etc., make XCode happy with imported headers. 

### DIFF
--- a/extensions/core-extensions.h
+++ b/extensions/core-extensions.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-#include <cmark_extension_api.h>
+#include "cmark_extension_api.h"
 #include "cmarkextensions_export.h"
 #include <stdint.h>
 

--- a/extensions/table.h
+++ b/extensions/table.h
@@ -3,6 +3,10 @@
 
 #include "core-extensions.h"
 
+
+extern cmark_node_type CMARK_NODE_TABLE, CMARK_NODE_TABLE_ROW,
+    CMARK_NODE_TABLE_CELL;
+
 cmark_syntax_extension *create_table_extension(void);
 
 #endif

--- a/src/cmark_extension_api.h
+++ b/src/cmark_extension_api.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-#include <cmark.h>
+#include "cmark.h"
 
 struct cmark_renderer;
 struct cmark_html_renderer;


### PR DESCRIPTION
Minimal changes. 