### PR TITLE
table extension: cosmetic fix for uniformity of output.

### DIFF
--- a/extensions/table.c
+++ b/extensions/table.c
@@ -578,10 +578,15 @@ static void html_render(cmark_syntax_extension *extension,
       cmark_strbuf_putc(html, '>');
       table_state->need_closing_table_body = false;
     } else {
-      if (table_state->need_closing_table_body)
+      if (table_state->need_closing_table_body) {
+        cmark_html_render_cr(html);
         cmark_strbuf_puts(html, "</tbody>");
+        cmark_html_render_cr(html);
+      }
       table_state->need_closing_table_body = false;
-      cmark_strbuf_puts(html, "</table>\n");
+      cmark_html_render_cr(html);
+      cmark_strbuf_puts(html, "</table>");
+      cmark_html_render_cr(html);
     }
   } else if (node->type == CMARK_NODE_TABLE_ROW) {
     if (entering) {

--- a/test/extensions-table-prefer-style-attributes.txt
+++ b/test/extensions-table-prefer-style-attributes.txt
@@ -32,5 +32,7 @@ fff | ggg | hhh | iii | jjj
 <td style="text-align: center">hhh</td>
 <td>iii</td>
 <td style="text-align: right">jjj</td>
-</tr></tbody></table>
+</tr>
+</tbody>
+</table>
 ````````````````````````````````

--- a/test/extensions.txt
+++ b/test/extensions.txt
@@ -31,7 +31,9 @@ Here's a well-formed table, doing everything it should.
 <tr>
 <td>mno</td>
 <td>pqr</td>
-</tr></tbody></table>
+</tr>
+</tbody>
+</table>
 ````````````````````````````````
 
 We're going to mix up the table now; we'll demonstrate that inline formatting
@@ -64,7 +66,9 @@ Hi!
 <tr>
 <td>But <em><strong>inline elements do</strong></em>.</td>
 <td>x</td>
-</tr></tbody></table>
+</tr>
+</tbody>
+</table>
 <p>Hi!</p>
 ````````````````````````````````
 
@@ -96,20 +100,23 @@ Here we demonstrate some edge cases about what is and isn't a table.
 <th>Just enough table</th>
 <th>to be considered table</th>
 </tr>
-</thead></table>
+</thead>
+</table>
 <p>| ---- | --- |</p>
 <table>
 <thead>
 <tr>
 <th>x</th>
 </tr>
-</thead></table>
+</thead>
+</table>
 <table>
 <thead>
 <tr>
 <th>xyz</th>
 </tr>
-</thead></table>
+</thead>
+</table>
 ````````````````````````````````
 
 A "simpler" table, GFM style:
@@ -130,7 +137,9 @@ xyz | ghi
 <tr>
 <td>xyz</td>
 <td>ghi</td>
-</tr></tbody></table>
+</tr>
+</tbody>
+</table>
 ````````````````````````````````
 
 We are making the parser slighly more lax here. Here is a table with spaces at
@@ -162,7 +171,9 @@ Hi!
 <tr>
 <td>But <em><strong>inline elements do</strong></em>.</td>
 <td>x</td>
-</tr></tbody></table>
+</tr>
+</tbody>
+</table>
 <p>Hi!</p>
 ````````````````````````````````
 
@@ -190,7 +201,9 @@ fff | ggg | hhh | iii | jjj
 <td align="center">hhh</td>
 <td>iii</td>
 <td align="right">jjj</td>
-</tr></tbody></table>
+</tr>
+</tbody>
+</table>
 ````````````````````````````````
 
 ### Table cell count mismatches
@@ -240,7 +253,9 @@ than the header are truncated.
 <td>1</td>
 <td>2</td>
 <td>3</td>
-</tr></tbody></table>
+</tr>
+</tbody>
+</table>
 ````````````````````````````````
 
 ### Embedded pipes
@@ -278,7 +293,9 @@ Tables with embedded pipes could be tricky.
 <tr>
 <td>don't <strong>_reparse_</strong></td>
 <td></td>
-</tr></tbody></table>
+</tr>
+</tbody>
+</table>
 ````````````````````````````````
 
 ### Oddly-formatted markers
@@ -294,7 +311,8 @@ This shouldn't assert.
 <tr>
 <th>a</th>
 </tr>
-</thead></table>
+</thead>
+</table>
 ````````````````````````````````
 
 ### Escaping
@@ -345,7 +363,9 @@ This shouldn't assert.
 <tr>
 <td>\a</td>
 <td><code>\a</code></td>
-</tr></tbody></table>
+</tr>
+</tbody>
+</table>
 <p>\ <code>\\</code></p>
 <p>\\ <code>\\\\</code></p>
 <p>_ <code>\_</code></p>
@@ -373,7 +393,9 @@ This shouldn't assert.
 </tr>
 <tr>
 <td>ok <br> sure</td>
-</tr></tbody></table>
+</tr>
+</tbody>
+</table>
 ````````````````````````````````
 
 ### Reference-style links
@@ -397,7 +419,9 @@ Here's a link to [Freedom Planet 2][].
 <tbody>
 <tr>
 <td>Here's a link to <a href="http://www.freedomplanet2.com/">Freedom Planet 2</a> in a table row.</td>
-</tr></tbody></table>
+</tr>
+</tbody>
+</table>
 ````````````````````````````````
 
 ### Sequential cells
@@ -420,7 +444,9 @@ Here's a link to [Freedom Planet 2][].
 <td>d</td>
 <td></td>
 <td>e</td>
-</tr></tbody></table>
+</tr>
+</tbody>
+</table>
 ````````````````````````````````
 
 ### Interaction with emphasis
@@ -441,7 +467,9 @@ Here's a link to [Freedom Planet 2][].
 <tr>
 <td><em><strong>(a)</strong></em></td>
 <td></td>
-</tr></tbody></table>
+</tr>
+</tbody>
+</table>
 ````````````````````````````````
 
 
@@ -670,5 +698,7 @@ Autolink and tables.
 <tr>
 <td><a href="https://github.com">https://github.com</a> <a href="http://www.github.com">www.github.com</a></td>
 <td><a href="http://pokemon.com">http://pokemon.com</a></td>
-</tr></tbody></table>
+</tr>
+</tbody>
+</table>
 ````````````````````````````````

--- a/test/spec.txt
+++ b/test/spec.txt
@@ -3257,7 +3257,9 @@ right, or center alignment respectively.
 <tr>
 <td>baz</td>
 <td>bim</td>
-</tr></tbody></table>
+</tr>
+</tbody>
+</table>
 ````````````````````````````````
 
 Cells in one column don't need to match length, though it's easier to read if
@@ -3279,7 +3281,9 @@ bar | baz
 <tr>
 <td align="center">bar</td>
 <td align="right">baz</td>
-</tr></tbody></table>
+</tr>
+</tbody>
+</table>
 ````````````````````````````````
 
 Include a pipe in a cell's content by escaping it, including inside other
@@ -3303,7 +3307,9 @@ inline spans:
 </tr>
 <tr>
 <td>b <strong>|</strong> im</td>
-</tr></tbody></table>
+</tr>
+</tbody>
+</table>
 ````````````````````````````````
 
 The table is broken at the first empty line, or beginning of another
@@ -3326,7 +3332,9 @@ block-level structure:
 <tr>
 <td>bar</td>
 <td>baz</td>
-</tr></tbody></table>
+</tr>
+</tbody>
+</table>
 <blockquote>
 <p>bar</p>
 </blockquote>
@@ -3355,7 +3363,9 @@ bar
 <tr>
 <td>bar</td>
 <td></td>
-</tr></tbody></table>
+</tr>
+</tbody>
+</table>
 <p>bar</p>
 ````````````````````````````````
 
@@ -3397,7 +3407,9 @@ cells are inserted.  If there are greater, the excess is ignored:
 <tr>
 <td>bar</td>
 <td>baz</td>
-</tr></tbody></table>
+</tr>
+</tbody>
+</table>
 ````````````````````````````````
 
 If there are no rows in the body, no `<tbody>` is generated in HTML output:
@@ -3412,7 +3424,8 @@ If there are no rows in the body, no `<tbody>` is generated in HTML output:
 <th>abc</th>
 <th>def</th>
 </tr>
-</thead></table>
+</thead>
+</table>
 ````````````````````````````````
 
 </div>


### PR DESCRIPTION
Previously we'd get

    </tr></tbody></table>

and

    </thead></table>

on one line, which isn't consistent with the general formatting
of the tables.  This changes the output to insert line breaks,
and updates tests and spec.