### PR TITLE
XML attribute formatters

### DIFF
--- a/extensions/cmark-gfm-core-extensions.h
+++ b/extensions/cmark-gfm-core-extensions.h
@@ -18,6 +18,9 @@ uint16_t cmark_gfm_extensions_get_table_columns(cmark_node *node);
 CMARK_GFM_EXTENSIONS_EXPORT
 uint8_t *cmark_gfm_extensions_get_table_alignments(cmark_node *node);
 
+CMARK_GFM_EXTENSIONS_EXPORT
+int cmark_gfm_extensions_get_table_row_is_header(cmark_node *node);
+
 #ifdef __cplusplus
 }
 #endif

--- a/extensions/table.c
+++ b/extensions/table.c
@@ -9,6 +9,7 @@
 #include "ext_scanners.h"
 #include "strikethrough.h"
 #include "table.h"
+#include "cmark-gfm-core-extensions.h"
 
 cmark_node_type CMARK_NODE_TABLE, CMARK_NODE_TABLE_ROW,
     CMARK_NODE_TABLE_CELL;
@@ -488,6 +489,27 @@ static void latex_render(cmark_syntax_extension *extension,
   }
 }
 
+static char *xml_attr(cmark_syntax_extension *extension,
+                      cmark_node *node) {
+  if (node->type == CMARK_NODE_TABLE_CELL) {
+    if (cmark_gfm_extensions_get_table_row_is_header(node->parent)) {
+      uint8_t *alignments = get_table_alignments(node->parent->parent);
+      int i = 0;
+      cmark_node *n;
+      for (n = node->parent->first_child; n; n = n->next, ++i)
+        if (n == node)
+          break;
+      switch (alignments[i]) {
+      case 'l': return strdup(" align=\"left\"");
+      case 'c': return strdup(" align=\"center\"");
+      case 'r': return strdup(" align=\"right\"");
+      }
+    }
+  }
+
+  return NULL;
+}
+
 static void man_render(cmark_syntax_extension *extension,
                        cmark_renderer *renderer, cmark_node *node,
                        cmark_event_type ev_type, int options) {
@@ -685,6 +707,7 @@ cmark_syntax_extension *create_table_extension(void) {
   cmark_syntax_extension_set_commonmark_render_func(self, commonmark_render);
   cmark_syntax_extension_set_plaintext_render_func(self, commonmark_render);
   cmark_syntax_extension_set_latex_render_func(self, latex_render);
+  cmark_syntax_extension_set_xml_attr_func(self, xml_attr);
   cmark_syntax_extension_set_man_render_func(self, man_render);
   cmark_syntax_extension_set_html_render_func(self, html_render);
   cmark_syntax_extension_set_opaque_alloc_func(self, opaque_alloc);
@@ -711,17 +734,17 @@ uint8_t *cmark_gfm_extensions_get_table_alignments(cmark_node *node) {
   return ((node_table *)node->as.opaque)->alignments;
 }
 
-int cmarkextensions_set_table_columns(cmark_node *node, uint16_t n_columns) {
+int cmark_gfm_extensions_set_table_columns(cmark_node *node, uint16_t n_columns) {
   return set_n_table_columns(node, n_columns);
 }
 
-int cmarkextensions_set_table_alignments(cmark_node *node, uint16_t ncols, uint8_t *alignments) {
+int cmark_gfm_extensions_set_table_alignments(cmark_node *node, uint16_t ncols, uint8_t *alignments) {
   uint8_t *a = (uint8_t *)cmark_node_mem(node)->calloc(1, ncols);
   memcpy(a, alignments, ncols);
   return set_table_alignments(node, a);
 }
 
-int cmarkextensions_get_table_row_is_header(cmark_node *node)
+int cmark_gfm_extensions_get_table_row_is_header(cmark_node *node)
 {
   if (!node || node->type != CMARK_NODE_TABLE_ROW)
     return 0;
@@ -729,7 +752,7 @@ int cmarkextensions_get_table_row_is_header(cmark_node *node)
   return ((node_table_row *)node->as.opaque)->is_header;
 }
 
-int cmarkextensions_set_table_row_is_header(cmark_node *node, int is_header)
+int cmark_gfm_extensions_set_table_row_is_header(cmark_node *node, int is_header)
 {
   if (!node || node->type != CMARK_NODE_TABLE_ROW)
     return 0;

--- a/src/cmark-gfm-extension_api.h
+++ b/src/cmark-gfm-extension_api.h
@@ -236,6 +236,9 @@ typedef int (*cmark_commonmark_escape_func) (cmark_syntax_extension *extension,
                                               cmark_node *node,
                                               int c);
 
+typedef char* (*cmark_xml_attr_func) (cmark_syntax_extension *extension,
+                                      cmark_node *node);
+
 typedef void (*cmark_html_render_func) (cmark_syntax_extension *extension,
                                         struct cmark_html_renderer *renderer,
                                         cmark_node *node,
@@ -343,6 +346,12 @@ void cmark_syntax_extension_set_latex_render_func(cmark_syntax_extension *extens
                                                   cmark_common_render_func func);
 
 /** See the documentation for 'cmark_syntax_extension'
+ */
+CMARK_GFM_EXPORT
+void cmark_syntax_extension_set_xml_attr_func(cmark_syntax_extension *extension,
+                                              cmark_xml_attr_func func);
+
+  /** See the documentation for 'cmark_syntax_extension'
  */
 CMARK_GFM_EXPORT
 void cmark_syntax_extension_set_man_render_func(cmark_syntax_extension *extension,

--- a/src/syntax_extension.c
+++ b/src/syntax_extension.c
@@ -97,6 +97,11 @@ void cmark_syntax_extension_set_latex_render_func(cmark_syntax_extension *extens
   extension->latex_render_func = func;
 }
 
+void cmark_syntax_extension_set_xml_attr_func(cmark_syntax_extension *extension,
+                                              cmark_xml_attr_func func) {
+  extension->xml_attr_func = func;
+}
+
 void cmark_syntax_extension_set_man_render_func(cmark_syntax_extension *extension,
                                                 cmark_common_render_func func) {
   extension->man_render_func = func;

--- a/src/syntax_extension.h
+++ b/src/syntax_extension.h
@@ -21,6 +21,7 @@ struct cmark_syntax_extension {
   cmark_common_render_func        commonmark_render_func;
   cmark_common_render_func        plaintext_render_func;
   cmark_common_render_func        latex_render_func;
+  cmark_xml_attr_func             xml_attr_func;
   cmark_common_render_func        man_render_func;
   cmark_html_render_func          html_render_func;
   cmark_html_filter_func          html_filter_func;

--- a/src/xml.c
+++ b/src/xml.c
@@ -8,6 +8,7 @@
 #include "node.h"
 #include "buffer.h"
 #include "houdini.h"
+#include "syntax_extension.h"
 
 #define BUFFER_SIZE 100
 
@@ -48,6 +49,14 @@ static int S_render_node(cmark_node *node, cmark_event_type ev_type,
                node->start_line, node->start_column, node->end_line,
                node->end_column);
       cmark_strbuf_puts(xml, buffer);
+    }
+
+    if (node->extension && node->extension->xml_attr_func) {
+      char* r = node->extension->xml_attr_func(node->extension, node);
+      if (r != NULL) {
+        cmark_strbuf_puts(xml, r);
+        free(r);
+      }
     }
 
     literal = false;


### PR DESCRIPTION
Gives extensions the opportunity to add attributes to XML nodes outputted for them. Fixes #115.

How does the output look to you, @jeroen?

Sample input:

```md
| a  | b  |  c  |  d |
| :- | -- | :-: | -: |
| l  | n  |  c  |  r |
```

Output:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE document SYSTEM "CommonMark.dtd">
<document xmlns="http://commonmark.org/xml/1.0">
  <table>
    <table_header>
      <table_cell align="left">
        <text xml:space="preserve">a</text>
      </table_cell>
      <table_cell>
        <text xml:space="preserve">b</text>
      </table_cell>
      <table_cell align="center">
        <text xml:space="preserve">c</text>
      </table_cell>
      <table_cell align="right">
        <text xml:space="preserve">d</text>
      </table_cell>
    </table_header>
    <table_row>
      <table_cell>
        <text xml:space="preserve">l</text>
      </table_cell>
      <table_cell>
        <text xml:space="preserve">n</text>
      </table_cell>
      <table_cell>
        <text xml:space="preserve">c</text>
      </table_cell>
      <table_cell>
        <text xml:space="preserve">r</text>
      </table_cell>
    </table_row>
  </table>
</document>
```

/cc @maelle @jeroen