### PR TITLE
Don't use empty attribute syntax in HTML renderer

### DIFF
--- a/src/html.c
+++ b/src/html.c
@@ -68,7 +68,7 @@ static bool S_put_footnote_backref(cmark_html_renderer *renderer, cmark_strbuf *
 
   cmark_strbuf_puts(html, "<a href=\"#fnref-");
   houdini_escape_href(html, node->as.literal.data, node->as.literal.len);
-  cmark_strbuf_puts(html, "\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"");
+  cmark_strbuf_puts(html, "\" class=\"footnote-backref\" data-footnote-backref=\"data-footnote-backref\" data-footnote-backref-idx=\"");
   cmark_strbuf_puts(html, m);
   cmark_strbuf_puts(html, "\" aria-label=\"Back to reference ");
   cmark_strbuf_puts(html, m);
@@ -84,7 +84,7 @@ static bool S_put_footnote_backref(cmark_html_renderer *renderer, cmark_strbuf *
       houdini_escape_href(html, node->as.literal.data, node->as.literal.len);
       cmark_strbuf_puts(html, "-");
       cmark_strbuf_puts(html, n);
-      cmark_strbuf_puts(html, "\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"");
+      cmark_strbuf_puts(html, "\" class=\"footnote-backref\" data-footnote-backref=\"data-footnote-backref\" data-footnote-backref-idx=\"");
       cmark_strbuf_puts(html, m);
       cmark_strbuf_puts(html, "-");
       cmark_strbuf_puts(html, n);
@@ -422,7 +422,7 @@ static int S_render_node(cmark_html_renderer *renderer, cmark_node *node,
   case CMARK_NODE_FOOTNOTE_DEFINITION:
     if (entering) {
       if (renderer->footnote_ix == 0) {
-        cmark_strbuf_puts(html, "<section class=\"footnotes\" data-footnotes>\n<ol>\n");
+        cmark_strbuf_puts(html, "<section class=\"footnotes\" data-footnotes=\"data-footnotes\">\n<ol>\n");
       }
       ++renderer->footnote_ix;
 
@@ -451,7 +451,7 @@ static int S_render_node(cmark_html_renderer *renderer, cmark_node *node,
         cmark_strbuf_puts(html, n);
       }
 
-      cmark_strbuf_puts(html, "\" data-footnote-ref>");
+      cmark_strbuf_puts(html, "\" data-footnote-ref=\"data-footnote-ref\">");
       houdini_escape_href(html, node->as.literal.data, node->as.literal.len);
       cmark_strbuf_puts(html, "</a></sup>");
     }


### PR DESCRIPTION
For context, this fixes issue #245 

Fixed a regression introduced in 0.29.0.gfm.2, where cmark-gfm would emit empty data-* attributes in HTML renderer, valid as HTML5, but invalid as XHTML.

I use cmark-gfm as part of my static site preprocessor and templating engine [microsounds/kagami](https://github.com/microsounds/kagami) which I use for my personal website and while it's not explicitly stated as a requirement, I strive for XHTML5 compliance, a robust subset of XHTML and HTML5 as [defined by W3C](https://www.w3.org/TR/xhtml1/diffs.html#h-4.5) and [WHATWG](https://wiki.whatwg.org/wiki/HTML_vs._XHTML#:~:text=attribute%20minimization%20is%20not%20allowed), and empty attribute syntax (attribute minimization) is invalid XHTML, preventing me from using my web browser's built in XHTML parser for strict syntax validation.