### PR TITLE
XML: add NODE_FOOTNOTE type strings and footnote emitters

### DIFF
--- a/src/node.c
+++ b/src/node.c
@@ -289,9 +289,9 @@ const char *cmark_node_get_type_string(cmark_node *node) {
   case CMARK_NODE_IMAGE:
     return "image";
   case CMARK_NODE_FOOTNOTE_REFERENCE:
-    return "fnref"
+    return "fnref";
   case CMARK_NODE_FOOTNOTE_DEFINITION:
-    return "fn"
+    return "fn";
   }
 
   return "<unknown>";

--- a/src/node.c
+++ b/src/node.c
@@ -288,6 +288,10 @@ const char *cmark_node_get_type_string(cmark_node *node) {
     return "link";
   case CMARK_NODE_IMAGE:
     return "image";
+  case CMARK_NODE_FOOTNOTE_REFERENCE:
+    return "fnref"
+  case CMARK_NODE_FOOTNOTE_DEFINITION:
+    return "fn"
   }
 
   return "<unknown>";

--- a/src/xml.c
+++ b/src/xml.c
@@ -134,6 +134,25 @@ static int S_render_node(cmark_node *node, cmark_event_type ev_type,
       escape_xml(xml, node->as.link.title.data, node->as.link.title.len);
       cmark_strbuf_putc(xml, '"');
       break;
+    case CMARK_NODE_FOOTNOTE_DEFINITION:
+      cmark_strbuf_puts(xml, " id=\"fn-");
+      escape_xml(xml, node->as.literal.data, node->as.literal.len);
+      cmark_strbuf_putc(xml, '"');
+      break;
+    case CMARK_NODE_FOOTNOTE_REFERENCE:
+      cmark_strbuf_puts(xml, " id=\"fnref-");
+      escape_xml(xml, node->parent_footnote_def->as.literal.data, node->parent_footnote_def->as.literal.len);
+      if (node->footnote.ref_ix > 1) {
+        char n[32];
+        snprintf(n, sizeof(n), "%d", node->footnote.ref_ix);
+        cmark_strbuf_puts(xml, "-");
+        cmark_strbuf_puts(xml, n);
+      }
+      cmark_strbuf_putc(xml, '"');
+      cmark_strbuf_puts(xml, " destination=\"fn-");
+      escape_xml(xml, node->parent_footnote_def->as.literal.data, node->parent_footnote_def->as.literal.len);
+      cmark_strbuf_putc(xml, '"');
+      break;
     default:
       break;
     }


### PR DESCRIPTION
I believe this will begin to address the issues in https://github.com/github/cmark-gfm/issues/341 and https://github.com/github/cmark-gfm/issues/316. 

(Update 2023-04-17: I added `id` and `destination` attributes to these nodes based on what I saw in the html writer)
 
I have run make test and everything passes for me. I have additionally tested this on a minimal document:

```markdown
---
title: "footnote"
---

let's insert a footnote[^1] and a duplicate[^1] another one[^foot]

[^1]: first footnote with a number

[^foot]: second footnote with a label
    
    and

    a linebreak.
```

```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE document SYSTEM "CommonMark.dtd">
<document xmlns="http://commonmark.org/xml/1.0">
  <thematic_break />
  <heading level="2">
    <text xml:space="preserve">title: &quot;footnote&quot;</text>
  </heading>
  <paragraph>
    <text xml:space="preserve">let's insert a footnote</text>
    <fnref id="fnref-1" destination="fn-1" />
    <text xml:space="preserve"> and a duplicate</text>
    <fnref id="fnref-1-2" destination="fn-1" />
    <text xml:space="preserve"> another one</text>
    <fnref id="fnref-foot" destination="fn-foot" />
  </paragraph>
  <fn id="fn-1">
    <paragraph>
      <text xml:space="preserve">first footnote with a number</text>
    </paragraph>
  </fn>
  <fn id="fn-foot">
    <paragraph>
      <text xml:space="preserve">second footnote with a label</text>
    </paragraph>
    <paragraph>
      <text xml:space="preserve">and</text>
    </paragraph>
    <paragraph>
      <text xml:space="preserve">a linebreak.</text>
    </paragraph>
  </fn>
</document>
```

I was not sure of what type labels to give the nodes, so I named them `fnref` and `fn` for the reference and the definition, respectively. If there is a more relevant precedent, then let's go for that. 

