### PR TITLE
Don't append a newline character when rendering inline nodes.

### DIFF
--- a/api_test/main.c
+++ b/api_test/main.c
@@ -689,7 +689,7 @@ static void render_commonmark(test_batch_runner *runner) {
   cmark_node *text = cmark_node_new(CMARK_NODE_TEXT);
   cmark_node_set_literal(text, "Hi");
   commonmark = cmark_render_commonmark(text, CMARK_OPT_DEFAULT, 0);
-  STR_EQ(runner, commonmark, "Hi\n", "render single inline node");
+  STR_EQ(runner, commonmark, "Hi", "render single inline node");
   free(commonmark);
 
   cmark_node_free(text);
@@ -733,7 +733,7 @@ static void render_plaintext(test_batch_runner *runner) {
   cmark_node *text = cmark_node_new(CMARK_NODE_TEXT);
   cmark_node_set_literal(text, "Hi");
   plaintext = cmark_render_plaintext(text, CMARK_OPT_DEFAULT, 0);
-  STR_EQ(runner, plaintext, "Hi\n", "render single inline node");
+  STR_EQ(runner, plaintext, "Hi", "render single inline node");
   free(plaintext);
 
   cmark_node_free(text);

--- a/src/render.c
+++ b/src/render.c
@@ -198,9 +198,11 @@ char *cmark_render(cmark_mem *mem, cmark_node *root, int options, int width,
     }
   }
 
-  // ensure final newline
-  if (renderer.buffer->size == 0 || renderer.buffer->ptr[renderer.buffer->size - 1] != '\n') {
-    cmark_strbuf_putc(renderer.buffer, '\n');
+  // If the root node is a block type (i.e. not inline), ensure there's a final newline:
+  if (CMARK_NODE_TYPE_BLOCK_P(root->type)) {
+    if (renderer.buffer->size == 0 || renderer.buffer->ptr[renderer.buffer->size - 1] != '\n') {
+      cmark_strbuf_putc(renderer.buffer, '\n');
+    }
   }
 
   result = (char *)cmark_strbuf_detach(renderer.buffer);


### PR DESCRIPTION
See <https://github.com/commonmark/cmark/issues/558> for context.