### PR TITLE
Revert "extensions: avoid useless duplication of headers"

### DIFF
--- a/extensions/CMakeLists.txt
+++ b/extensions/CMakeLists.txt
@@ -17,6 +17,8 @@ include_directories(
   ${PROJECT_BINARY_DIR}/src
 )
 
+include (GenerateExportHeader)
+
 include_directories(. ${CMAKE_CURRENT_BINARY_DIR})
 
 set(CMAKE_C_FLAGS_PROFILE "${CMAKE_C_FLAGS_RELEASE} -pg")
@@ -27,7 +29,6 @@ if (CMARK_SHARED)
 
   set_target_properties(${LIBRARY} PROPERTIES
     OUTPUT_NAME "cmark-gfm-extensions"
-    DEFINE_SYMBOL "cmark-gfm"
     SOVERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}.gfm.${PROJECT_VERSION_GFM}
     VERSION ${PROJECT_VERSION})
 
@@ -36,6 +37,9 @@ if (CMARK_SHARED)
 
   # Avoid name clash between PROGRAM and LIBRARY pdb files.
   set_target_properties(${LIBRARY} PROPERTIES PDB_NAME cmark-gfm-extensions_dll)
+
+  generate_export_header(${LIBRARY}
+    BASE_NAME cmark-gfm-extensions)
 
   list(APPEND CMARK_INSTALL ${LIBRARY})
   target_link_libraries(${LIBRARY} libcmark-gfm)
@@ -47,7 +51,6 @@ if (CMARK_STATIC)
 
   set_target_properties(${STATICLIBRARY} PROPERTIES
     COMPILE_FLAGS "-DCMARK_GFM_STATIC_DEFINE -DCMARK_GFM_EXTENSIONS_STATIC_DEFINE"
-    DEFINE_SYMBOL "cmark-gfm"
     POSITION_INDEPENDENT_CODE ON)
 
   if (MSVC)
@@ -59,6 +62,11 @@ if (CMARK_STATIC)
       OUTPUT_NAME "cmark-gfm-extensions"
       VERSION ${PROJECT_VERSION})
   endif(MSVC)
+
+  if (NOT CMARK_SHARED)
+    generate_export_header(${STATICLIBRARY}
+      BASE_NAME cmark-gfm-extensions)
+  endif()
 
   list(APPEND CMARK_INSTALL ${STATICLIBRARY})
 endif()
@@ -76,6 +84,7 @@ install(TARGETS ${CMARK_INSTALL}
 if (CMARK_SHARED OR CMARK_STATIC)
   install(FILES
   cmark-gfm-core-extensions.h
+  ${CMAKE_CURRENT_BINARY_DIR}/cmark-gfm-extensions_export.h
   DESTINATION include
   )
 

--- a/extensions/cmark-gfm-core-extensions.h
+++ b/extensions/cmark-gfm-core-extensions.h
@@ -6,45 +6,45 @@ extern "C" {
 #endif
 
 #include "cmark-gfm-extension_api.h"
-#include "cmark-gfm_export.h"
+#include "cmark-gfm-extensions_export.h"
 #include <stdbool.h>
 #include <stdint.h>
 
-CMARK_GFM_EXPORT
+CMARK_GFM_EXTENSIONS_EXPORT
 void cmark_gfm_core_extensions_ensure_registered(void);
 
-CMARK_GFM_EXPORT
+CMARK_GFM_EXTENSIONS_EXPORT
 uint16_t cmark_gfm_extensions_get_table_columns(cmark_node *node);
 
 /** Sets the number of columns for the table, returning 1 on success and 0 on error.
  */
-CMARK_GFM_EXPORT
+CMARK_GFM_EXTENSIONS_EXPORT
 int cmark_gfm_extensions_set_table_columns(cmark_node *node, uint16_t n_columns);
 
-CMARK_GFM_EXPORT
+CMARK_GFM_EXTENSIONS_EXPORT
 uint8_t *cmark_gfm_extensions_get_table_alignments(cmark_node *node);
 
 /** Sets the alignments for the table, returning 1 on success and 0 on error.
  */
-CMARK_GFM_EXPORT
+CMARK_GFM_EXTENSIONS_EXPORT
 int cmark_gfm_extensions_set_table_alignments(cmark_node *node, uint16_t ncols, uint8_t *alignments);
 
-CMARK_GFM_EXPORT
+CMARK_GFM_EXTENSIONS_EXPORT
 int cmark_gfm_extensions_get_table_row_is_header(cmark_node *node);
 
 /** Sets whether the node is a table header row, returning 1 on success and 0 on error.
  */
-CMARK_GFM_EXPORT
+CMARK_GFM_EXTENSIONS_EXPORT
 int cmark_gfm_extensions_set_table_row_is_header(cmark_node *node, int is_header);
 
-CMARK_GFM_EXPORT
+CMARK_GFM_EXTENSIONS_EXPORT
 bool cmark_gfm_extensions_get_tasklist_item_checked(cmark_node *node);
 /* For backwards compatibility */
 #define cmark_gfm_extensions_tasklist_is_checked cmark_gfm_extensions_get_tasklist_item_checked
 
 /** Sets whether a tasklist item is "checked" (completed), returning 1 on success and 0 on error.
  */
-CMARK_GFM_EXPORT
+CMARK_GFM_EXTENSIONS_EXPORT
 int cmark_gfm_extensions_set_tasklist_item_checked(cmark_node *node, bool is_checked);
 
 #ifdef __cplusplus


### PR DESCRIPTION
This reverts commit e08c5523b662f022a37bae28494a8c17b5c5097b from https://github.com/github/cmark-gfm/pull/289.

The headers aren't duplicated on Windows and CYGWIN. There, [`CMARK_GFM_EXTENSIONS_EXPORT` resolves to `__declspec(dllexport)` and `__declspec(dllimport)`](https://gitlab.kitware.com/cmake/cmake/-/blob/4559f5770f746174927c9ec733bf5b26e2ab1efe/Modules/GenerateExportHeader.cmake#L305-307) depending on whether the dynamic library is built or used.  Since `cmark-gfm-extensions` is a separate shared library, it needs a separate header (it needs to import the stuff from `cmark-gfm` and export its own things). This can't be done with one exports header from CMake.