### PR TITLE
Patches from Debian package

### DIFF
--- a/api_test/main.c
+++ b/api_test/main.c
@@ -942,6 +942,13 @@ static void test_feed_across_line_ending(test_batch_runner *runner) {
 #  include <sys/time.h>
 static struct timeval _before, _after;
 static int _timing;
+static int _timing_scale = 1;
+#  define SETUP_TIMING()                        \
+  do {                                          \
+    char *scale = getenv("CMARK_TIMING_SCALE"); \
+    if (scale)                                  \
+      _timing_scale = atoi(scale);              \
+  } while (0)
 #  define START_TIMING() \
        gettimeofday(&_before, NULL)
 
@@ -952,10 +959,13 @@ static int _timing;
         } while (0)
 
 #  define TIMING _timing
+#  define TIMING_SCALE _timing_scale
 #else
+#  define SETUP_TIMING()
 #  define START_TIMING()
 #  define END_TIMING()
 #  define TIMING 0
+#  define TIMING_SCALE 1
 #endif
 
 static void test_pathological_regressions(test_batch_runner *runner) {
@@ -973,7 +983,8 @@ static void test_pathological_regressions(test_batch_runner *runner) {
     free(html);
     free(input);
 
-    OK(runner, TIMING < 1000, "takes less than 1000ms to run");
+    OK(runner, TIMING < 1000 * TIMING_SCALE,
+       "takes less than CMARK_TIMING_SCALE * 1000ms to run");
   }
 
   {
@@ -989,7 +1000,8 @@ static void test_pathological_regressions(test_batch_runner *runner) {
     free(html);
     free(input);
 
-    OK(runner, TIMING < 1000, "takes less than 1000ms to run");
+    OK(runner, TIMING < 1000 * TIMING_SCALE,
+       "takes less than CMARK_TIMING_SCALE * 1000ms to run");
   }
 }
 
@@ -1133,6 +1145,7 @@ int main() {
   int retval;
   test_batch_runner *runner = test_batch_runner_new();
 
+  SETUP_TIMING();
   cmark_enable_safety_checks(true);
   version(runner);
   constructor(runner);

--- a/man/man1/cmark-gfm.1
+++ b/man/man1/cmark-gfm.1
@@ -66,6 +66,18 @@ URLs are those that begin with `javascript:`, `vbscript:`,
 `file:`, or `data:` (except for `image/png`, `image/gif`,
 `image/jpeg`, or `image/webp` mime types).
 .TP 12n
+.B \-\-github-pre-lang
+Use GitHub-style <pre lang> for code blocks.
+.TP 12n
+.B \-\-strikethrough-double-tilde
+Only parse strikethrough (if enabled) with two tildes.
+.TP 12n
+.B \-\-table-prefer-style-attributes
+Use style attributes to align table cells instead of align attributes.
+.TP 12n
+.B \-\-full-info-string
+Include remainder of code block info string in a separate attribute.
+.TP 12n
 .B \-\-help
 Print usage information.
 .TP 12n

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -175,6 +175,10 @@ if(CMARK_SHARED OR CMARK_STATIC)
     DESTINATION include
     )
 
+  install(FILES ${HEADERS}
+    DESTINATION include/cmark-gfm
+    )
+
   install(EXPORT cmark-gfm DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
 endif()
 

--- a/test/normalize.py
+++ b/test/normalize.py
@@ -18,7 +18,7 @@ import re
 # Normalization code, adapted from
 # https://github.com/karlcow/markdown-testsuite/
 significant_attrs = ["alt", "href", "src", "title"]
-whitespace_re = re.compile('\s+')
+whitespace_re = re.compile('\\s+')
 class MyHTMLParser(HTMLParser):
     def __init__(self):
         HTMLParser.__init__(self)
@@ -176,7 +176,7 @@ def normalize_html(html):
         '\u2200&amp;&gt;&lt;&quot;'
 
     """
-    html_chunk_re = re.compile("(\<!\[CDATA\[.*?\]\]\>|\<[^>]*\>|[^<]+)")
+    html_chunk_re = re.compile("(\\<!\\[CDATA\\[.*?\\]\\]\\>|\\<[^>]*\\>|[^<]+)")
     try:
         parser = MyHTMLParser()
         # We work around HTMLParser's limitations parsing CDATA

--- a/test/pathological_tests.py
+++ b/test/pathological_tests.py
@@ -146,12 +146,12 @@ if __name__ == '__main__':
             p.terminate()
             p.join()
             print('[TIMED OUT]')
-            if allowed_failures[description]:
+            if description in allowed_failures:
                 ignored += 1
             else:
                 errored += 1
         elif p.exitcode != 0:
-            if allowed_failures[description]:
+            if description in allowed_failures:
                 ignored += 1
             else:
                 errored += 1

--- a/test/pathological_tests.py
+++ b/test/pathological_tests.py
@@ -7,6 +7,7 @@ import sys
 import platform
 import itertools
 import multiprocessing
+import os
 from cmark import CMark
 
 def hash_collisions():
@@ -106,7 +107,8 @@ whitespace_re = re.compile('/s+/')
 passed = 0
 errored = 0
 ignored = 0
-TIMEOUT = 5
+timing_scale = float(os.getenv("CMARK_TIMING_SCALE", "1"))
+TIMEOUT = 5 * timing_scale
 
 def run_test(inp, regex):
     parser = argparse.ArgumentParser(description='Run cmark tests.')

--- a/test/pathological_tests.py
+++ b/test/pathological_tests.py
@@ -30,7 +30,7 @@ def hash_collisions():
 
     document = ''.join("[%s]: /url\n\n[%s]\n\n" % (key, bad_key) for key in collisions)
 
-    return document, re.compile("(<p>\[%s\]</p>\n){%d}" % (bad_key, COUNT-1))
+    return document, re.compile("(<p>\\[%s\\]</p>\n){%d}" % (bad_key, COUNT-1))
 
 allowed_failures = {"many references": True}
 
@@ -48,10 +48,10 @@ pathological = {
                   re.compile("(_a ){64999}_a")),
     "many link closers with no openers":
                  (("a]" * 65000),
-                  re.compile("(a\]){65000}")),
+                  re.compile("(a\\]){65000}")),
     "many link openers with no closers":
                  (("[a" * 65000),
-                  re.compile("(\[a){65000}")),
+                  re.compile("(\\[a){65000}")),
     "mismatched openers and closers":
                  (("*a_ " * 50000),
                   re.compile("([*]a[_] ){49999}[*]a_")),
@@ -60,19 +60,19 @@ pathological = {
                   re.compile("a[*][*]b(c[*] ){49999}c[*]")),
     "link openers and emph closers":
                  (("[ a_" * 50000),
-                  re.compile("(\[ a_){50000}")),
+                  re.compile("(\\[ a_){50000}")),
     "pattern [ (]( repeated":
                  (("[ (](" * 80000),
-                  re.compile("(\[ \(\]\(){80000}")),
+                  re.compile("(\\[ \\(\\]\\(){80000}")),
     "pattern ![[]() repeated":
                  ("![[]()" * 160000,
-                  re.compile("(!\[<a href=\"\"></a>){160000}")),
+                  re.compile("(!\\[<a href=\"\"></a>){160000}")),
     "hard link/emph case":
                  ("**x [a*b**c*](d)",
                   re.compile("\\*\\*x <a href=\"d\">a<em>b\\*\\*c</em></a>")),
     "nested brackets":
                  (("[" * 50000) + "a" + ("]" * 50000),
-                  re.compile("\[{50000}a\]{50000}")),
+                  re.compile("\\[{50000}a\\]{50000}")),
     "nested block quotes":
                  ((("> " * 50000) + "a"),
                   re.compile("(<blockquote>\n){50000}")),
@@ -87,13 +87,13 @@ pathological = {
                   re.compile("^<p>[e`]*</p>\n$")),
     "unclosed links A":
                  ("[a](<b" * 30000,
-                  re.compile("(\[a\]\(&lt;b){30000}")),
+                  re.compile("(\\[a\\]\\(&lt;b){30000}")),
     "unclosed links B":
                  ("[a](b" * 30000,
-                  re.compile("(\[a\]\(b){30000}")),
+                  re.compile("(\\[a\\]\\(b){30000}")),
     "unclosed <!--":
                  ("</" + "<!--" * 300000,
-                  re.compile("\&lt;\/(\&lt;!--){300000}")),
+                  re.compile("\\&lt;\\/(\\&lt;!--){300000}")),
     "tables":
                  ("aaa\rbbb\n-\v\n" * 30000,
                   re.compile("^<p>aaa</p>\n<table>\n<thead>\n<tr>\n<th>bbb</th>\n</tr>\n</thead>\n<tbody>\n(<tr>\n<td>aaa</td>\n</tr>\n<tr>\n<td>bbb</td>\n</tr>\n<tr>\n<td>-\x0b</td>\n</tr>\n){29999}</tbody>\n</table>\n$")),


### PR DESCRIPTION
Here's a set of patches that I wrote as a part of packaging cmark-gfm for Debian.

 1. Install more headers for library users. I'm unsure whether these are still required, but as of gfm.6 they were.
 2. Add missing command line options to the man page.
 3. Add an environment variable, CMARK_TIMING_SCALE, to increase test timeouts. Some debian targets are so slow that even the generous timeouts aren't long enough. I use `CMARK_TIMING_SCALE=10` for debian packaging to ensure that even hppa builds work.
 4. Fix python regex syntax errors in tests. Back slashes must be escaped (with another backslash) in regex strings.
 5. test/pathological_tests.py was using `allowed_failures` incorrectly.