### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI tests
 
 on: [push, workflow_dispatch]
+permissions:
+  contents: read
 
 jobs:
   linux:


### PR DESCRIPTION
Potential fix for [https://github.com/github/cmark-gfm/security/code-scanning/5](https://github.com/github/cmark-gfm/security/code-scanning/5)

The best fix is to add a `permissions:` block specifying least privilege, i.e., `contents: read`, at the root of the workflow file just below the `name:` and before or after the `on:` key. This will apply to all jobs since no job-specific `permissions` blocks are present. This change restricts the `GITHUB_TOKEN` to read-only access to repository contents, protecting against potential privilege escalation. No changes to functionality or jobs are required, as none of the steps require more than read access. The edit is a simple insertion of a few lines in `.github/workflows/ci.yml` near the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
