### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI tests
+permissions:
+  contents: read
 
 on: [push, workflow_dispatch]
 


### PR DESCRIPTION
Potential fix for [https://github.com/github/cmark-gfm/security/code-scanning/4](https://github.com/github/cmark-gfm/security/code-scanning/4)

The best fix is to explicitly add a `permissions` block specifying only the required permissions—ideally as restrictive as possible. Since this workflow is only checking out code and running tests, and does not interact with GitHub’s API in ways requiring write access, `contents: read` is sufficient. This should be added at the root level of the workflow (just below the workflow `name:` and before `on:`), so that all jobs inherit this least-privileged setting.  
No other changes, imports, or definitions are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
