### PR TITLE
[Added]: Streaming AST API for LLM-streamed markdown

### DIFF
--- a/api_test/main.c
+++ b/api_test/main.c
@@ -938,6 +938,615 @@ static void test_feed_across_line_ending(test_batch_runner *runner) {
   cmark_node_free(document);
 }
 
+// Streaming AST tests — exercise snapshot, change events, and node-morph
+// pointer stability across paragraph -> setext-heading rewrites.
+static void test_streaming_ast(test_batch_runner *runner) {
+  // Snapshot returns the live root and is non-NULL even before finish.
+  {
+    cmark_parser *p = cmark_parser_new(CMARK_OPT_DEFAULT);
+    cmark_parser_feed(p, "Hello", 5);
+    cmark_node *snap = cmark_parser_snapshot(p);
+    OK(runner, snap != NULL, "snapshot returns non-null root before finish");
+    INT_EQ(runner, (int)cmark_node_get_type(snap), (int)CMARK_NODE_DOCUMENT,
+           "snapshot root is document");
+    cmark_parser_free(p);
+  }
+
+  // commit_frontier starts at zero and is monotonically non-decreasing.
+  // After "abc\n\ndef\n" the first paragraph is finalized (the blank line
+  // closed it and rules out setext/table promotion), so the frontier
+  // advances to at least the byte immediately after that paragraph (= 4,
+  // the start of the blank line). The second paragraph is still open and
+  // provisional, so the frontier does not include its bytes.
+  {
+    cmark_parser *p = cmark_parser_new(CMARK_OPT_DEFAULT);
+    INT_EQ(runner, (int)cmark_parser_commit_frontier(p), 0,
+           "commit_frontier starts at 0");
+    cmark_parser_feed(p, "abc\n\ndef\n", 9);
+    size_t f = cmark_parser_commit_frontier(p);
+    OK(runner, f >= 4 && f <= 5,
+       "commit_frontier advanced past committed first paragraph");
+    // Monotonicity: feeding the close of the second paragraph extends it
+    // but never moves frontier backwards.
+    cmark_parser_feed(p, "\n", 1);
+    size_t f2 = cmark_parser_commit_frontier(p);
+    OK(runner, f2 >= f, "commit_frontier is monotonically non-decreasing");
+    cmark_parser_free(p);
+  }
+
+  // The setext-rewrite path emits a RETYPED event, and the
+  // affected node retains its pointer identity across the morph.
+  {
+    cmark_parser *p = cmark_parser_new(CMARK_OPT_DEFAULT);
+    cmark_parser_feed(p, "Hello\n", 6);
+    cmark_node *snap = cmark_parser_snapshot(p);
+    cmark_node *para = cmark_node_first_child(snap);
+    OK(runner, para != NULL, "paragraph node exists after first line");
+    INT_EQ(runner, (int)cmark_node_get_type(para),
+           (int)CMARK_NODE_PARAGRAPH, "first child is paragraph");
+
+    // Discard initial change records (paragraph creation, etc.).
+    cmark_change_iter *it0 =
+        cmark_parser_changes_since_last_snapshot(p);
+    cmark_node *n0;
+    while (cmark_change_iter_next(it0, &n0) != CMARK_CHANGE_NONE) { }
+    cmark_change_iter_free(it0);
+
+    // The setext underline arrives, rewriting the paragraph in place.
+    cmark_parser_feed(p, "=====\n", 6);
+
+    cmark_change_iter *it = cmark_parser_changes_since_last_snapshot(p);
+    int retyped_seen = 0;
+    int retyped_was_para = 0;
+    int retyped_node_is_same = 0;
+    cmark_node *n;
+    cmark_change_event k;
+    while ((k = cmark_change_iter_next(it, &n)) != CMARK_CHANGE_NONE) {
+      if (k == CMARK_CHANGE_NODE_RETYPED) {
+        retyped_seen++;
+        if (n == para)
+          retyped_node_is_same = 1;
+        if (cmark_node_get_type(n) == CMARK_NODE_HEADING)
+          retyped_was_para = 1;
+      }
+    }
+    cmark_change_iter_free(it);
+
+    OK(runner, retyped_seen == 1,
+       "exactly one RETYPED record for paragraph->setext");
+    OK(runner, retyped_node_is_same,
+       "RETYPED node pointer matches original paragraph (in-place morph)");
+    OK(runner, retyped_was_para,
+       "RETYPED node is now a heading");
+    INT_EQ(runner, (int)cmark_node_get_type(para),
+           (int)CMARK_NODE_HEADING,
+           "in-place morph: paragraph pointer is now a heading");
+
+    cmark_node *doc = cmark_parser_finish(p);
+    cmark_parser_free(p);
+    cmark_node_free(doc);
+  }
+
+  // Paragraph -> GFM table head also reaches us via cmark_node_set_type
+  // (extensions/table.c calls it when promoting the paragraph). The
+  // RETYPED record should fire for that path too.
+  {
+    cmark_gfm_core_extensions_ensure_registered();
+    cmark_parser *p = cmark_parser_new(CMARK_OPT_DEFAULT);
+    cmark_syntax_extension *table_ext =
+        cmark_find_syntax_extension("table");
+    OK(runner, table_ext != NULL, "found table extension");
+    cmark_parser_attach_syntax_extension(p, table_ext);
+
+    cmark_parser_feed(p, "Header 1 | Header 2\n", 20);
+    cmark_node *snap = cmark_parser_snapshot(p);
+    cmark_node *para = cmark_node_first_child(snap);
+    OK(runner, para != NULL && cmark_node_get_type(para) == CMARK_NODE_PARAGRAPH,
+       "first child is paragraph before delimiter row");
+
+    cmark_change_iter *it0 =
+        cmark_parser_changes_since_last_snapshot(p);
+    cmark_node *n0;
+    while (cmark_change_iter_next(it0, &n0) != CMARK_CHANGE_NONE) { }
+    cmark_change_iter_free(it0);
+
+    cmark_parser_feed(p, "--- | ---\n", 10);
+
+    cmark_change_iter *it = cmark_parser_changes_since_last_snapshot(p);
+    int retyped_seen = 0;
+    int retyped_node_is_same = 0;
+    cmark_node *n;
+    cmark_change_event k;
+    while ((k = cmark_change_iter_next(it, &n)) != CMARK_CHANGE_NONE) {
+      if (k == CMARK_CHANGE_NODE_RETYPED && n == para) {
+        retyped_seen++;
+        retyped_node_is_same = 1;
+      }
+    }
+    cmark_change_iter_free(it);
+
+    OK(runner, retyped_seen >= 1,
+       "RETYPED record emitted for paragraph->table morph");
+    OK(runner, retyped_node_is_same,
+       "RETYPED node pointer matches original paragraph (table morph)");
+
+    cmark_node *doc = cmark_parser_finish(p);
+    cmark_parser_free(p);
+    cmark_node_free(doc);
+  }
+
+  // P2: open blocks carry CMARK_NODE__PROVISIONAL. Closed blocks lose it
+  // and emit a FINALIZED record. After cmark_parser_finish nothing is
+  // provisional.
+  {
+    cmark_parser *p = cmark_parser_new(CMARK_OPT_DEFAULT);
+    // Need at least one terminated line before a block exists in the AST.
+    // (cmark_parser_feed buffers partial lines until \n.)
+    cmark_parser_feed(p, "Hello\n", 6);
+    cmark_node *snap = cmark_parser_snapshot(p);
+    cmark_node *para = cmark_node_first_child(snap);
+    OK(runner, para != NULL, "open paragraph exists");
+    OK(runner, cmark_node_is_provisional(para),
+       "open paragraph is provisional");
+    OK(runner, !cmark_node_is_provisional(snap),
+       "document root is never provisional");
+
+    // Drain change records before the close.
+    cmark_change_iter *it0 =
+        cmark_parser_changes_since_last_snapshot(p);
+    cmark_node *n0; while (cmark_change_iter_next(it0, &n0)
+                          != CMARK_CHANGE_NONE) { }
+    cmark_change_iter_free(it0);
+
+    // Blank line closes the paragraph and rules out setext/table.
+    cmark_parser_feed(p, "\n", 1);
+    cmark_change_iter *it = cmark_parser_changes_since_last_snapshot(p);
+    int finalized_seen = 0;
+    int finalized_was_para = 0;
+    cmark_node *n; cmark_change_event k;
+    while ((k = cmark_change_iter_next(it, &n)) != CMARK_CHANGE_NONE) {
+      if (k == CMARK_CHANGE_NODE_FINALIZED) {
+        finalized_seen++;
+        if (n == para) finalized_was_para = 1;
+      }
+    }
+    cmark_change_iter_free(it);
+    OK(runner, finalized_seen >= 1,
+       "at least one FINALIZED record on paragraph close");
+    OK(runner, finalized_was_para,
+       "FINALIZED record references the paragraph node by identity");
+    OK(runner, !cmark_node_is_provisional(para),
+       "paragraph is no longer provisional after close");
+
+    cmark_node *doc = cmark_parser_finish(p);
+    // Walk the tree — no node should remain provisional.
+    {
+      cmark_iter *iter = cmark_iter_new(doc);
+      cmark_event_type ev;
+      int leftover_provisional = 0;
+      while ((ev = cmark_iter_next(iter)) != CMARK_EVENT_DONE) {
+        if (ev == CMARK_EVENT_ENTER &&
+            cmark_node_is_provisional(cmark_iter_get_node(iter))) {
+          leftover_provisional++;
+        }
+      }
+      cmark_iter_free(iter);
+      INT_EQ(runner, leftover_provisional, 0,
+             "no provisional nodes after finish");
+    }
+    cmark_parser_free(p);
+    cmark_node_free(doc);
+  }
+
+  // P3: snapshot returns a tree with inline children populated. A closed
+  // emphasis becomes EMPH; an unclosed delimiter falls back to literal text.
+  {
+    cmark_parser *p = cmark_parser_new(CMARK_OPT_DEFAULT);
+    cmark_parser_feed(p, "Hello *world*\n", 14);
+    cmark_node *snap = cmark_parser_snapshot(p);
+    cmark_node *para = cmark_node_first_child(snap);
+    OK(runner, para != NULL && cmark_node_get_type(para) == CMARK_NODE_PARAGRAPH,
+       "first child is a paragraph");
+    // Walk inline children: expect TEXT, EMPH(TEXT).
+    cmark_node *first_inline = cmark_node_first_child(para);
+    OK(runner, first_inline != NULL,
+       "snapshot populated inline children");
+    int saw_emph = 0;
+    for (cmark_node *c = first_inline; c; c = cmark_node_next(c)) {
+      if (cmark_node_get_type(c) == CMARK_NODE_EMPH)
+        saw_emph = 1;
+    }
+    OK(runner, saw_emph,
+       "closed *...* surfaces as CMARK_NODE_EMPH after snapshot");
+    cmark_node *doc = cmark_parser_finish(p);
+    cmark_parser_free(p);
+    cmark_node_free(doc);
+  }
+
+  // P3: an open paragraph with an unclosed `*` snapshots as literal text;
+  // once the closer arrives, a re-parse yields EMPH.
+  {
+    cmark_parser *p = cmark_parser_new(CMARK_OPT_DEFAULT);
+    cmark_parser_feed(p, "Hello *world\n", 13);
+    cmark_node *snap1 = cmark_parser_snapshot(p);
+    cmark_node *para = cmark_node_first_child(snap1);
+    int saw_emph_before = 0;
+    for (cmark_node *c = cmark_node_first_child(para); c;
+         c = cmark_node_next(c)) {
+      if (cmark_node_get_type(c) == CMARK_NODE_EMPH) saw_emph_before = 1;
+    }
+    OK(runner, !saw_emph_before,
+       "unclosed `*` is literal text in interim snapshot");
+
+    // Append the closer on a continuation line; paragraph re-parses.
+    cmark_parser_feed(p, "again*\n", 7);
+    cmark_node *snap2 = cmark_parser_snapshot(p);
+    cmark_node *para2 = cmark_node_first_child(snap2);
+    OK(runner, para2 == para, "paragraph pointer identity preserved");
+    int saw_emph_after = 0;
+    for (cmark_node *c = cmark_node_first_child(para2); c;
+         c = cmark_node_next(c)) {
+      if (cmark_node_get_type(c) == CMARK_NODE_EMPH) saw_emph_after = 1;
+    }
+    OK(runner, saw_emph_after,
+       "closer arrival turns the run into EMPH on next snapshot");
+    cmark_node *doc = cmark_parser_finish(p);
+    cmark_parser_free(p);
+    cmark_node_free(doc);
+  }
+
+  // Direction 1: a code block's content grows across snapshots; consumers
+  // must see CONTENT_UPDATED records (INLINES_REPARSED would be wrong since
+  // code blocks have no inlines).
+  {
+    cmark_parser *p = cmark_parser_new(CMARK_OPT_DEFAULT);
+    cmark_parser_feed(p, "```\nfirst\n", 10);
+    cmark_node *snap1 = cmark_parser_snapshot(p);
+    // Drain all change records so far.
+    cmark_change_iter *it0 = cmark_parser_changes_since_last_snapshot(p);
+    cmark_node *n0;
+    while (cmark_change_iter_next(it0, &n0) != CMARK_CHANGE_NONE) { }
+    cmark_change_iter_free(it0);
+
+    cmark_parser_feed(p, "second\n", 7);
+    cmark_parser_snapshot(p);
+    cmark_change_iter *it = cmark_parser_changes_since_last_snapshot(p);
+    int content_updated = 0;
+    int inlines_reparsed = 0;
+    cmark_node *n; cmark_change_event k;
+    while ((k = cmark_change_iter_next(it, &n)) != CMARK_CHANGE_NONE) {
+      if (k == CMARK_CHANGE_NODE_CONTENT_UPDATED) content_updated++;
+      if (k == CMARK_CHANGE_NODE_INLINES_REPARSED) inlines_reparsed++;
+    }
+    cmark_change_iter_free(it);
+    OK(runner, content_updated >= 1,
+       "code block emits CONTENT_UPDATED when its content grows");
+    INT_EQ(runner, inlines_reparsed, 0,
+           "code block does not emit INLINES_REPARSED (no inlines)");
+    (void)snap1;
+    cmark_node *doc = cmark_parser_finish(p);
+    cmark_parser_free(p);
+    cmark_node_free(doc);
+  }
+
+  // Direction 2: an unmatched `*` in an open paragraph carries
+  // INLINE_PROVISIONAL on its TEXT node, distinguishing "tentatively
+  // unclosed emphasis" from "literal asterisk". When a closer arrives, the
+  // flag should disappear (the run becomes EMPH instead of TEXT).
+  {
+    cmark_parser *p = cmark_parser_new(CMARK_OPT_DEFAULT);
+    cmark_parser_feed(p, "Hello *partial\n", 15);
+    cmark_node *snap1 = cmark_parser_snapshot(p);
+    cmark_node *para = cmark_node_first_child(snap1);
+    int saw_inline_provisional = 0;
+    for (cmark_node *c = cmark_node_first_child(para); c;
+         c = cmark_node_next(c)) {
+      if (cmark_node_is_provisional(c) &&
+          cmark_node_get_type(c) == CMARK_NODE_TEXT) {
+        saw_inline_provisional = 1;
+      }
+    }
+    OK(runner, saw_inline_provisional,
+       "unmatched `*` in open block is INLINE_PROVISIONAL on its TEXT");
+    // Provide the closer; the EMPH that materializes should NOT be
+    // INLINE_PROVISIONAL.
+    cmark_parser_feed(p, "more*\n", 6);
+    cmark_parser_snapshot(p);
+    int still_provisional_text = 0;
+    int saw_emph_clean = 0;
+    for (cmark_node *c = cmark_node_first_child(para); c;
+         c = cmark_node_next(c)) {
+      if (cmark_node_get_type(c) == CMARK_NODE_TEXT &&
+          (c->flags & CMARK_NODE__INLINE_PROVISIONAL)) {
+        still_provisional_text = 1;
+      }
+      if (cmark_node_get_type(c) == CMARK_NODE_EMPH &&
+          !(c->flags & CMARK_NODE__INLINE_PROVISIONAL)) {
+        saw_emph_clean = 1;
+      }
+    }
+    OK(runner, !still_provisional_text,
+       "after closer arrives, no TEXT child carries INLINE_PROVISIONAL");
+    OK(runner, saw_emph_clean,
+       "the resolved EMPH is not INLINE_PROVISIONAL");
+    cmark_node *doc = cmark_parser_finish(p);
+    cmark_parser_free(p);
+    cmark_node_free(doc);
+  }
+
+  // Direction 3: eager ref-def extraction. Refs resolve as soon as the def
+  // is followed by a non-whitespace byte that proves it is bounded — no
+  // trailing blank line needed.
+  {
+    cmark_parser *p = cmark_parser_new(CMARK_OPT_DEFAULT);
+    cmark_parser_feed(p, "Click [foo] now.\n\n", 18);
+    // Para 1 finalized; pending [foo] registered.
+    cmark_parser_feed(p, "[foo]: http://x.example\n", 24);
+    // Para 2 still open; eager-extract sees parsed_len == content.size, defers.
+    cmark_node *snap1 = cmark_parser_snapshot(p);
+    cmark_node *para1 = cmark_node_first_child(snap1);
+    int link_before = 0;
+    for (cmark_node *c = cmark_node_first_child(para1); c;
+         c = cmark_node_next(c)) {
+      if (cmark_node_get_type(c) == CMARK_NODE_LINK) link_before = 1;
+    }
+    OK(runner, !link_before,
+       "before bounding evidence arrives, [foo] is unresolved");
+
+    // A non-whitespace next-line proves the def is bounded.
+    cmark_parser_feed(p, "Aftertext\n", 10);
+    cmark_node *snap2 = cmark_parser_snapshot(p);
+    cmark_node *para1_again = cmark_node_first_child(snap2);
+    OK(runner, para1_again == para1,
+       "para1 pointer identity preserved across eager-extract round");
+    int link_after = 0;
+    const char *url = NULL;
+    for (cmark_node *c = cmark_node_first_child(para1_again); c;
+         c = cmark_node_next(c)) {
+      if (cmark_node_get_type(c) == CMARK_NODE_LINK) {
+        link_after = 1;
+        url = cmark_node_get_url(c);
+      }
+    }
+    OK(runner, link_after,
+       "[foo] resolves to LINK after eager extraction (no blank line needed)");
+    OK(runner, url && strcmp(url, "http://x.example") == 0,
+       "eagerly-extracted def carries correct URL");
+    cmark_node *doc = cmark_parser_finish(p);
+    cmark_parser_free(p);
+    cmark_node_free(doc);
+  }
+
+  // Direction 3: safety — when content following a def is whitespace, we
+  // MUST defer (could be a title-continuation). One-shot must agree with
+  // streamed result.
+  {
+    const char *input = "[foo]: http://x.example\n   \"my title\"\n\nUse [foo].\n";
+    size_t len = strlen(input);
+    cmark_node *one = cmark_parse_document(input, len, CMARK_OPT_DEFAULT);
+    char *html_one = cmark_render_html(one, CMARK_OPT_DEFAULT, NULL);
+
+    cmark_parser *p = cmark_parser_new(CMARK_OPT_DEFAULT);
+    for (size_t i = 0; i < len; ++i) {
+      cmark_parser_feed(p, input + i, 1);
+      cmark_parser_snapshot(p);
+    }
+    cmark_node *streamed = cmark_parser_finish(p);
+    char *html_stream = cmark_render_html(streamed, CMARK_OPT_DEFAULT, NULL);
+    STR_EQ(runner, html_stream, html_one,
+           "title-continuation safety: streamed HTML matches one-shot");
+    free(html_one); free(html_stream);
+    cmark_node_free(one); cmark_node_free(streamed);
+    cmark_parser_free(p);
+  }
+
+  // P5: when a [foo] reference is parsed before its definition arrives, the
+  // containing paragraph gets re-parsed once the definition is added.
+  {
+    cmark_parser *p = cmark_parser_new(CMARK_OPT_DEFAULT);
+    // Paragraph 1 references [foo] which has no def yet.
+    cmark_parser_feed(p, "See [foo] for details\n\n", 23);
+    cmark_node *snap1 = cmark_parser_snapshot(p);
+    cmark_node *para = cmark_node_first_child(snap1);
+    OK(runner, para != NULL, "paragraph created");
+    // Walk inline children — should contain no LINK before def arrives.
+    int link_before = 0;
+    for (cmark_node *c = cmark_node_first_child(para); c;
+         c = cmark_node_next(c)) {
+      if (cmark_node_get_type(c) == CMARK_NODE_LINK) link_before = 1;
+    }
+    OK(runner, !link_before,
+       "[foo] is plain text before definition arrives");
+
+    // Now feed the definition. The blank line closes the def-bearing
+    // paragraph, which is the trigger for resolve_reference_link_definitions
+    // to populate the refmap (CommonMark requirement).
+    cmark_parser_feed(p, "[foo]: http://example.com\n\n", 27);
+    cmark_node *snap2 = cmark_parser_snapshot(p);
+    // Paragraph 1's pointer should be unchanged; [foo] should now be a LINK.
+    cmark_node *para2 = cmark_node_first_child(snap2);
+    OK(runner, para2 == para,
+       "ref-resolved paragraph keeps pointer identity");
+    int link_after = 0;
+    const char *link_url = NULL;
+    for (cmark_node *c = cmark_node_first_child(para2); c;
+         c = cmark_node_next(c)) {
+      if (cmark_node_get_type(c) == CMARK_NODE_LINK) {
+        link_after = 1;
+        link_url = cmark_node_get_url(c);
+      }
+    }
+    OK(runner, link_after,
+       "[foo] re-parses as CMARK_NODE_LINK after definition arrives");
+    OK(runner, link_url && strcmp(link_url, "http://example.com") == 0,
+       "resolved link carries the correct URL");
+    cmark_node *doc = cmark_parser_finish(p);
+    cmark_parser_free(p);
+    cmark_node_free(doc);
+  }
+
+  // P2: a paragraph that is just a reference definition gets removed at
+  // finalize; we should see a NODE_REMOVED record (and no FINALIZED for it).
+  {
+    cmark_parser *p = cmark_parser_new(CMARK_OPT_DEFAULT);
+    cmark_parser_feed(p, "[foo]: http://example.com\n", 26);
+    // Drain ADDED/etc.
+    cmark_change_iter *it0 =
+        cmark_parser_changes_since_last_snapshot(p);
+    cmark_node *n0; while (cmark_change_iter_next(it0, &n0)
+                          != CMARK_CHANGE_NONE) { }
+    cmark_change_iter_free(it0);
+    cmark_parser_feed(p, "\n", 1); // close the paragraph
+    cmark_change_iter *it =
+        cmark_parser_changes_since_last_snapshot(p);
+    int removed_seen = 0;
+    cmark_node *n; cmark_change_event k;
+    while ((k = cmark_change_iter_next(it, &n)) != CMARK_CHANGE_NONE) {
+      if (k == CMARK_CHANGE_NODE_REMOVED) removed_seen++;
+    }
+    cmark_change_iter_free(it);
+    OK(runner, removed_seen == 1,
+       "ref-def-only paragraph emits exactly one NODE_REMOVED");
+    cmark_node *doc = cmark_parser_finish(p);
+    cmark_parser_free(p);
+    cmark_node_free(doc);
+  }
+}
+
+// Differential validation: for a representative corpus of markdown inputs,
+// confirm that streaming parse with snapshots-between-every-byte produces
+// the same final HTML as a one-shot parse. Also confirms monotonicity of
+// commit_frontier and that no node remains provisional after finish.
+static void test_streaming_convergence(test_batch_runner *runner) {
+  static const char *corpus[] = {
+    "Hello world\n",
+    "Hello\n=====\n",
+    "# Heading\n\nParagraph with *emphasis* and **strong**.\n",
+    "- item one\n- item two\n- item three\n",
+    "1. one\n2. two\n\n3. three (loose)\n",
+    "> blockquote line one\n> line two\n",
+    "```c\nint main(void){return 0;}\n```\n",
+    "    indented code\n    second line\n",
+    "Header 1 | Header 2\n--- | ---\nA | B\nC | D\n",
+    "See [foo] for more.\n\n[foo]: http://example.com \"title\"\n",
+    "First paragraph.\n\nSecond with `code` and a [link](http://x.com).\n",
+    "<p>raw html</p>\n\nThen prose.\n",
+    "Paragraph one.\nLine two of paragraph one.\n\nParagraph two.\n",
+    "Mix: **bold *nested italic* still bold** plain\n",
+    // Direction 3 edge cases:
+    //  - title-on-continuation-line. Eager extract MUST defer until full
+    //    title arrives, otherwise streamed-vs-oneshot diverges.
+    "[foo]: http://x.example\n   \"title here\"\n\nUse [foo].\n",
+    //  - multiple back-to-back defs. The first is provably bounded by the
+    //    second `[`, so eager extract should fire.
+    "[a]: http://a.example\n[b]: http://b.example\n\nSee [a] and [b].\n",
+    //  - def followed by non-title non-whitespace prose.
+    "[a]: http://a.example\nNot a title line.\n\nUsing [a].\n",
+    //  - unclosed emphasis spanning multiple lines, then closed.
+    "Open *star\nstill open\nnow closed*\n",
+  };
+  size_t n = sizeof(corpus) / sizeof(*corpus);
+
+  for (size_t i = 0; i < n; ++i) {
+    const char *input = corpus[i];
+    size_t input_len = strlen(input);
+
+    // Reference: one-shot parse + render.
+    cmark_node *one = cmark_parse_document(input, input_len, CMARK_OPT_DEFAULT);
+    char *html_one = cmark_render_html(one, CMARK_OPT_DEFAULT, NULL);
+
+    // Streamed: feed byte-by-byte, snapshot after each, then finish.
+    cmark_parser *p = cmark_parser_new(CMARK_OPT_DEFAULT);
+    size_t prev_frontier = 0;
+    int monotonic = 1;
+    for (size_t k = 0; k < input_len; ++k) {
+      cmark_parser_feed(p, input + k, 1);
+      cmark_parser_snapshot(p);
+      size_t f = cmark_parser_commit_frontier(p);
+      if (f < prev_frontier) monotonic = 0;
+      prev_frontier = f;
+    }
+    cmark_node *streamed = cmark_parser_finish(p);
+    char *html_stream = cmark_render_html(streamed, CMARK_OPT_DEFAULT, NULL);
+
+    // No node should remain provisional after finish.
+    int leftover = 0;
+    cmark_iter *iter = cmark_iter_new(streamed);
+    cmark_event_type ev;
+    while ((ev = cmark_iter_next(iter)) != CMARK_EVENT_DONE) {
+      if (ev == CMARK_EVENT_ENTER &&
+          cmark_node_is_provisional(cmark_iter_get_node(iter))) {
+        leftover++;
+      }
+    }
+    cmark_iter_free(iter);
+
+    OK(runner, monotonic, "convergence[%zu]: commit_frontier monotonic", i);
+    INT_EQ(runner, leftover, 0,
+           "convergence[%zu]: no provisional nodes after finish", i);
+    STR_EQ(runner, html_stream, html_one,
+           "convergence[%zu]: streaming HTML == one-shot HTML", i);
+
+    free(html_one);
+    free(html_stream);
+    cmark_node_free(one);
+    cmark_node_free(streamed);
+    cmark_parser_free(p);
+  }
+
+  // Same convergence guarantee with GFM extensions enabled — exercises the
+  // paragraph -> table morph and the strikethrough/autolink inline paths.
+  cmark_gfm_core_extensions_ensure_registered();
+  static const char *gfm_corpus[] = {
+    "Header 1 | Header 2\n--- | ---\nA | B\nC | D\n",
+    "Mix ~strike~ and **bold** text.\n",
+    "Visit https://example.com today.\n",
+    "Tasks:\n- [ ] todo\n- [x] done\n",
+  };
+  size_t gn = sizeof(gfm_corpus) / sizeof(*gfm_corpus);
+  for (size_t i = 0; i < gn; ++i) {
+    const char *input = gfm_corpus[i];
+    size_t input_len = strlen(input);
+
+    // Helper: build a parser with GFM core extensions attached.
+    #define ATTACH_GFM_EXTS(p) do { \
+      const char *exts[] = {"table","strikethrough","autolink","tasklist"}; \
+      for (size_t e = 0; e < sizeof(exts)/sizeof(*exts); ++e) { \
+        cmark_syntax_extension *x = cmark_find_syntax_extension(exts[e]); \
+        if (x) cmark_parser_attach_syntax_extension((p), x); \
+      } \
+    } while (0)
+
+    cmark_parser *one_p = cmark_parser_new(CMARK_OPT_DEFAULT);
+    ATTACH_GFM_EXTS(one_p);
+    cmark_parser_feed(one_p, input, input_len);
+    cmark_node *one = cmark_parser_finish(one_p);
+    char *html_one = cmark_render_html(one, CMARK_OPT_DEFAULT,
+                                       cmark_parser_get_syntax_extensions(one_p));
+    cmark_parser_free(one_p);
+
+    cmark_parser *p = cmark_parser_new(CMARK_OPT_DEFAULT);
+    ATTACH_GFM_EXTS(p);
+    for (size_t k = 0; k < input_len; ++k) {
+      cmark_parser_feed(p, input + k, 1);
+      cmark_parser_snapshot(p);
+    }
+    cmark_node *streamed = cmark_parser_finish(p);
+    char *html_stream = cmark_render_html(streamed, CMARK_OPT_DEFAULT,
+                                          cmark_parser_get_syntax_extensions(p));
+
+    STR_EQ(runner, html_stream, html_one,
+           "gfm-convergence[%zu]: streaming HTML == one-shot HTML", i);
+
+    free(html_one);
+    free(html_stream);
+    cmark_node_free(one);
+    cmark_node_free(streamed);
+    cmark_parser_free(p);
+    #undef ATTACH_GFM_EXTS
+  }
+}
+
 #if !defined(_WIN32) || defined(__CYGWIN__)
 #  include <sys/time.h>
 static struct timeval _before, _after;
@@ -1156,6 +1765,8 @@ int main() {
   test_cplusplus(runner);
   test_safe(runner);
   test_feed_across_line_ending(runner);
+  test_streaming_ast(runner);
+  test_streaming_convergence(runner);
   test_pathological_regressions(runner);
   source_pos(runner);
   source_pos_inlines(runner);

--- a/man/man3/cmark-gfm.3
+++ b/man/man3/cmark-gfm.3
@@ -1,8 +1,9 @@
-.TH cmark-gfm 3 "April 08, 2019" "LOCAL" "Library Functions Manual"
+.TH cmark-gfm 3 "May 05, 2026" "LOCAL" "Library Functions Manual"
 .SH
 NAME
 .PP
-\f[B]cmark\-gfm\f[] \- CommonMark parsing, manipulating, and rendering
+\f[B]cmark\-gfm\f[] \- CommonMark parsing, manipulating, and
+rendering
 
 .SH
 DESCRIPTION
@@ -13,9 +14,9 @@ Simple Interface
 \fIchar *\f[] \fBcmark_markdown_to_html\f[](\fIconst char *text\f[], \fIsize_t len\f[], \fIint options\f[])
 
 .PP
-Convert \f[I]text\f[] (assumed to be a UTF\-8 encoded string with length
-\f[I]len\f[]) from CommonMark Markdown to HTML, returning a
-null\-terminated, UTF\-8\-encoded string. It is the caller's
+Convert \f[I]text\f[] (assumed to be a UTF\-8 encoded string with
+length \f[I]len\f[]) from CommonMark Markdown to HTML, returning
+a null\-terminated, UTF\-8\-encoded string. It is the caller's
 responsibility to free the returned buffer.
 
 .SS
@@ -108,18 +109,18 @@ typedef struct cmark_mem {
 .fi
 
 .PP
-Defines the memory allocation functions to be used by CMark when parsing
-and allocating a document tree
+Defines the memory allocation functions to be used by CMark when
+parsing and allocating a document tree
 
 .PP
-\fIcmark_mem *\f[] \fBcmark_get_default_mem_allocator\f[](\fI\f[])
+\fIcmark_mem *\f[] \fBcmark_get_default_mem_allocator\f[](\fIvoid\f[])
 
 .PP
-The default memory allocator; uses the system's calloc, realloc and
-free.
+The default memory allocator; uses the system's calloc, realloc
+and free.
 
 .PP
-\fIcmark_mem *\f[] \fBcmark_get_arena_mem_allocator\f[](\fI\f[])
+\fIcmark_mem *\f[] \fBcmark_get_arena_mem_allocator\f[](\fIvoid\f[])
 
 .PP
 An arena allocator; uses system calloc to allocate large slabs of
@@ -129,8 +130,8 @@ memory. Memory in these slabs is not reused at all.
 \fIvoid\f[] \fBcmark_arena_reset\f[](\fIvoid\f[])
 
 .PP
-Resets the arena allocator, quickly returning all used memory to the
-operating system.
+Resets the arena allocator, quickly returning all used memory to
+the operating system.
 
 .PP
 \fItypedef\f[] \fBvoid\f[](\fI*cmark_free_func\f[])
@@ -161,15 +162,15 @@ A generic singly linked list.
 \fIcmark_llist *\f[] \fBcmark_llist_append\f[](\fIcmark_mem         * mem\f[], \fIcmark_llist       * head\f[], \fIvoid              * data\f[])
 
 .PP
-Append an element to the linked list, return the possibly modified head
-of the list.
+Append an element to the linked list, return the possibly
+modified head of the list.
 
 .PP
 \fIvoid\f[] \fBcmark_llist_free_full\f[](\fIcmark_mem         * mem\f[], \fIcmark_llist       * head\f[], \fIcmark_free_func     free_func\f[])
 
 .PP
-Free the list starting with \f[I]head\f[], calling \f[I]free_func\f[]
-with the data pointer of each of its elements
+Free the list starting with \f[I]head\f[], calling
+\f[I]free_func\f[] with the data pointer of each of its elements
 
 .PP
 \fIvoid\f[] \fBcmark_llist_free\f[](\fIcmark_mem         * mem\f[], \fIcmark_llist       * head\f[])
@@ -184,17 +185,18 @@ Creating and Destroying Nodes
 \fIcmark_node *\f[] \fBcmark_node_new\f[](\fIcmark_node_type type\f[])
 
 .PP
-Creates a new node of type \f[I]type\f[]. Note that the node may have
-other required properties, which it is the caller's responsibility to
-assign.
+Creates a new node of type \f[I]type\f[]. Note that the node may
+have other required properties, which it is the caller's
+responsibility to assign.
 
 .PP
 \fIcmark_node *\f[] \fBcmark_node_new_with_mem\f[](\fIcmark_node_type type\f[], \fIcmark_mem *mem\f[])
 
 .PP
-Same as \f[C]cmark_node_new\f[], but explicitly listing the memory
-allocator used to allocate the node. Note: be sure to use the same
-allocator for every node in a tree, or bad things can happen.
+Same as \f[C]cmark_node_new\f[], but explicitly listing the
+memory allocator used to allocate the node. Note: be sure to use
+the same allocator for every node in a tree, or bad things can
+happen.
 
 .PP
 \fIvoid\f[] \fBcmark_node_free\f[](\fIcmark_node *node\f[])
@@ -209,15 +211,15 @@ Tree Traversal
 \fIcmark_node *\f[] \fBcmark_node_next\f[](\fIcmark_node *node\f[])
 
 .PP
-Returns the next node in the sequence after \f[I]node\f[], or NULL if
-there is none.
+Returns the next node in the sequence after \f[I]node\f[], or
+NULL if there is none.
 
 .PP
 \fIcmark_node *\f[] \fBcmark_node_previous\f[](\fIcmark_node *node\f[])
 
 .PP
-Returns the previous node in the sequence after \f[I]node\f[], or NULL
-if there is none.
+Returns the previous node in the sequence after \f[I]node\f[], or
+NULL if there is none.
 
 .PP
 \fIcmark_node *\f[] \fBcmark_node_parent\f[](\fIcmark_node *node\f[])
@@ -229,31 +231,40 @@ Returns the parent of \f[I]node\f[], or NULL if there is none.
 \fIcmark_node *\f[] \fBcmark_node_first_child\f[](\fIcmark_node *node\f[])
 
 .PP
-Returns the first child of \f[I]node\f[], or NULL if \f[I]node\f[] has
-no children.
+Returns the first child of \f[I]node\f[], or NULL if
+\f[I]node\f[] has no children.
 
 .PP
 \fIcmark_node *\f[] \fBcmark_node_last_child\f[](\fIcmark_node *node\f[])
 
 .PP
-Returns the last child of \f[I]node\f[], or NULL if \f[I]node\f[] has no
-children.
+Returns the last child of \f[I]node\f[], or NULL if \f[I]node\f[]
+has no children.
+
+.PP
+\fIcmark_node *\f[] \fBcmark_node_parent_footnote_def\f[](\fIcmark_node *node\f[])
+
+.PP
+Returns the footnote reference of \f[I]node\f[], or NULL if
+\f[I]node\f[] doesn't have a footnote reference.
 
 .SS
 Iterator
 .PP
-An iterator will walk through a tree of nodes, starting from a root
-node, returning one node at a time, together with information about
-whether the node is being entered or exited. The iterator will first
-descend to a child node, if there is one. When there is no child, the
-iterator will go to the next sibling. When there is no next sibling, the
-iterator will return to the parent (but with a \f[I]cmark_event_type\f[]
-of \f[C]CMARK_EVENT_EXIT\f[]). The iterator will return
-\f[C]CMARK_EVENT_DONE\f[] when it reaches the root node again. One
-natural application is an HTML renderer, where an \f[C]ENTER\f[] event
-outputs an open tag and an \f[C]EXIT\f[] event outputs a close tag. An
-iterator might also be used to transform an AST in some systematic way,
-for example, turning all level\-3 headings into regular paragraphs.
+An iterator will walk through a tree of nodes, starting from a
+root node, returning one node at a time, together with
+information about whether the node is being entered or exited.
+The iterator will first descend to a child node, if there is one.
+When there is no child, the iterator will go to the next sibling.
+When there is no next sibling, the iterator will return to the
+parent (but with a \f[I]cmark_event_type\f[] of
+\f[C]CMARK_EVENT_EXIT\f[]). The iterator will return
+\f[C]CMARK_EVENT_DONE\f[] when it reaches the root node again.
+One natural application is an HTML renderer, where an
+\f[C]ENTER\f[] event outputs an open tag and an \f[C]EXIT\f[]
+event outputs a close tag. An iterator might also be used to
+transform an AST in some systematic way, for example, turning all
+level\-3 headings into regular paragraphs.
 .IP
 .nf
 \f[C]
@@ -272,8 +283,8 @@ usage_example(cmark_node *root) {
 \f[]
 .fi
 .PP
-Iterators will never return \f[C]EXIT\f[] events for leaf nodes, which
-are nodes of type:
+Iterators will never return \f[C]EXIT\f[] events for leaf nodes,
+which are nodes of type:
 .IP \[bu] 2
 CMARK_NODE_HTML_BLOCK
 .IP \[bu] 2
@@ -314,10 +325,11 @@ typedef enum {
 \fIcmark_iter *\f[] \fBcmark_iter_new\f[](\fIcmark_node *root\f[])
 
 .PP
-Creates a new iterator starting at \f[I]root\f[]. The current node and
-event type are undefined until \f[I]cmark_iter_next\f[] is called for
-the first time. The memory allocated for the iterator should be released
-using \f[I]cmark_iter_free\f[] when it is no longer needed.
+Creates a new iterator starting at \f[I]root\f[]. The current
+node and event type are undefined until \f[I]cmark_iter_next\f[]
+is called for the first time. The memory allocated for the
+iterator should be released using \f[I]cmark_iter_free\f[] when
+it is no longer needed.
 
 .PP
 \fIvoid\f[] \fBcmark_iter_free\f[](\fIcmark_iter *iter\f[])
@@ -355,9 +367,9 @@ Returns the root node.
 \fIvoid\f[] \fBcmark_iter_reset\f[](\fIcmark_iter *iter\f[], \fIcmark_node *current\f[], \fIcmark_event_type event_type\f[])
 
 .PP
-Resets the iterator so that the current node is \f[I]current\f[] and the
-event type is \f[I]event_type\f[]. The new current node must be a
-descendant of the root node or the root node itself.
+Resets the iterator so that the current node is \f[I]current\f[]
+and the event type is \f[I]event_type\f[]. The new current node
+must be a descendant of the root node or the root node itself.
 
 .SS
 Accessors
@@ -372,8 +384,8 @@ Returns the user data of \f[I]node\f[].
 \fIint\f[] \fBcmark_node_set_user_data\f[](\fIcmark_node *node\f[], \fIvoid *user_data\f[])
 
 .PP
-Sets arbitrary user data for \f[I]node\f[]. Returns 1 on success, 0 on
-failure.
+Sets arbitrary user data for \f[I]node\f[]. Returns 1 on success,
+0 on failure.
 
 .PP
 \fIint\f[] \fBcmark_node_set_user_data_free_func\f[](\fIcmark_node *node\f[], \fIcmark_free_func free_func\f[])
@@ -385,57 +397,58 @@ Set free function for user data */
 \fIcmark_node_type\f[] \fBcmark_node_get_type\f[](\fIcmark_node *node\f[])
 
 .PP
-Returns the type of \f[I]node\f[], or \f[C]CMARK_NODE_NONE\f[] on error.
+Returns the type of \f[I]node\f[], or \f[C]CMARK_NODE_NONE\f[] on
+error.
 
 .PP
 \fIconst char *\f[] \fBcmark_node_get_type_string\f[](\fIcmark_node *node\f[])
 
 .PP
-Like \f[I]cmark_node_get_type\f[], but returns a string representation
-of the type, or \f[C]"<unknown>"\f[].
+Like \f[I]cmark_node_get_type\f[], but returns a string
+representation of the type, or \f[C]"<unknown>"\f[].
 
 .PP
 \fIconst char *\f[] \fBcmark_node_get_literal\f[](\fIcmark_node *node\f[])
 
 .PP
-Returns the string contents of \f[I]node\f[], or an empty string if none
-is set. Returns NULL if called on a node that does not have string
-content.
+Returns the string contents of \f[I]node\f[], or an empty string
+if none is set. Returns NULL if called on a node that does not
+have string content.
 
 .PP
 \fIint\f[] \fBcmark_node_set_literal\f[](\fIcmark_node *node\f[], \fIconst char *content\f[])
 
 .PP
-Sets the string contents of \f[I]node\f[]. Returns 1 on success, 0 on
-failure.
+Sets the string contents of \f[I]node\f[]. Returns 1 on success,
+0 on failure.
 
 .PP
 \fIint\f[] \fBcmark_node_get_heading_level\f[](\fIcmark_node *node\f[])
 
 .PP
-Returns the heading level of \f[I]node\f[], or 0 if \f[I]node\f[] is not
-a heading.
+Returns the heading level of \f[I]node\f[], or 0 if \f[I]node\f[]
+is not a heading.
 
 .PP
 \fIint\f[] \fBcmark_node_set_heading_level\f[](\fIcmark_node *node\f[], \fIint level\f[])
 
 .PP
-Sets the heading level of \f[I]node\f[], returning 1 on success and 0 on
-error.
+Sets the heading level of \f[I]node\f[], returning 1 on success
+and 0 on error.
 
 .PP
 \fIcmark_list_type\f[] \fBcmark_node_get_list_type\f[](\fIcmark_node *node\f[])
 
 .PP
-Returns the list type of \f[I]node\f[], or \f[C]CMARK_NO_LIST\f[] if
-\f[I]node\f[] is not a list.
+Returns the list type of \f[I]node\f[], or \f[C]CMARK_NO_LIST\f[]
+if \f[I]node\f[] is not a list.
 
 .PP
 \fIint\f[] \fBcmark_node_set_list_type\f[](\fIcmark_node *node\f[], \fIcmark_list_type type\f[])
 
 .PP
-Sets the list type of \f[I]node\f[], returning 1 on success and 0 on
-error.
+Sets the list type of \f[I]node\f[], returning 1 on success and 0
+on error.
 
 .PP
 \fIcmark_delim_type\f[] \fBcmark_node_get_list_delim\f[](\fIcmark_node *node\f[])
@@ -448,15 +461,15 @@ Returns the list delimiter type of \f[I]node\f[], or
 \fIint\f[] \fBcmark_node_set_list_delim\f[](\fIcmark_node *node\f[], \fIcmark_delim_type delim\f[])
 
 .PP
-Sets the list delimiter type of \f[I]node\f[], returning 1 on success
-and 0 on error.
+Sets the list delimiter type of \f[I]node\f[], returning 1 on
+success and 0 on error.
 
 .PP
 \fIint\f[] \fBcmark_node_get_list_start\f[](\fIcmark_node *node\f[])
 
 .PP
-Returns starting number of \f[I]node\f[], if it is an ordered list,
-otherwise 0.
+Returns starting number of \f[I]node\f[], if it is an ordered
+list, otherwise 0.
 
 .PP
 \fIint\f[] \fBcmark_node_set_list_start\f[](\fIcmark_node *node\f[], \fIint start\f[])
@@ -475,7 +488,23 @@ Returns 1 if \f[I]node\f[] is a tight list, 0 otherwise.
 \fIint\f[] \fBcmark_node_set_list_tight\f[](\fIcmark_node *node\f[], \fIint tight\f[])
 
 .PP
-Sets the "tightness" of a list. Returns 1 on success, 0 on failure.
+Sets the "tightness" of a list. Returns 1 on success, 0 on
+failure.
+
+.PP
+\fIint\f[] \fBcmark_node_get_item_index\f[](\fIcmark_node *node\f[])
+
+.PP
+Returns item index of \f[I]node\f[]. This is only used when
+rendering output formats such as commonmark, which need to output
+the index. It is not required for formats such as html or latex.
+
+.PP
+\fIint\f[] \fBcmark_node_set_item_index\f[](\fIcmark_node *node\f[], \fIint idx\f[])
+
+.PP
+Sets item index of \f[I]node\f[]. Returns 1 on success, 0 on
+failure.
 
 .PP
 \fIconst char *\f[] \fBcmark_node_get_fence_info\f[](\fIcmark_node *node\f[])
@@ -487,8 +516,8 @@ Returns the info string from a fenced code block.
 \fIint\f[] \fBcmark_node_set_fence_info\f[](\fIcmark_node *node\f[], \fIconst char *info\f[])
 
 .PP
-Sets the info string in a fenced code block, returning 1 on success
-and 0 on failure.
+Sets the info string in a fenced code block, returning 1 on
+success and 0 on failure.
 
 .PP
 \fIint\f[] \fBcmark_node_set_fenced\f[](\fIcmark_node * node\f[], \fIint fenced\f[], \fIint length\f[], \fIint offset\f[], \fIchar character\f[])
@@ -506,63 +535,63 @@ Returns code blocks fencing details
 \fIconst char *\f[] \fBcmark_node_get_url\f[](\fIcmark_node *node\f[])
 
 .PP
-Returns the URL of a link or image \f[I]node\f[], or an empty string if
-no URL is set. Returns NULL if called on a node that is not a link or
-image.
+Returns the URL of a link or image \f[I]node\f[], or an empty
+string if no URL is set. Returns NULL if called on a node that is
+not a link or image.
 
 .PP
 \fIint\f[] \fBcmark_node_set_url\f[](\fIcmark_node *node\f[], \fIconst char *url\f[])
 
 .PP
-Sets the URL of a link or image \f[I]node\f[]. Returns 1 on success, 0
-on failure.
+Sets the URL of a link or image \f[I]node\f[]. Returns 1 on
+success, 0 on failure.
 
 .PP
 \fIconst char *\f[] \fBcmark_node_get_title\f[](\fIcmark_node *node\f[])
 
 .PP
-Returns the title of a link or image \f[I]node\f[], or an empty string
-if no title is set. Returns NULL if called on a node that is not a link
-or image.
+Returns the title of a link or image \f[I]node\f[], or an empty
+string if no title is set. Returns NULL if called on a node that
+is not a link or image.
 
 .PP
 \fIint\f[] \fBcmark_node_set_title\f[](\fIcmark_node *node\f[], \fIconst char *title\f[])
 
 .PP
-Sets the title of a link or image \f[I]node\f[]. Returns 1 on success, 0
-on failure.
+Sets the title of a link or image \f[I]node\f[]. Returns 1 on
+success, 0 on failure.
 
 .PP
 \fIconst char *\f[] \fBcmark_node_get_on_enter\f[](\fIcmark_node *node\f[])
 
 .PP
-Returns the literal "on enter" text for a custom \f[I]node\f[], or an
-empty string if no on_enter is set. Returns NULL if called on a
-non\-custom node.
+Returns the literal "on enter" text for a custom \f[I]node\f[],
+or an empty string if no on_enter is set. Returns NULL if called
+on a non\-custom node.
 
 .PP
 \fIint\f[] \fBcmark_node_set_on_enter\f[](\fIcmark_node *node\f[], \fIconst char *on_enter\f[])
 
 .PP
-Sets the literal text to render "on enter" for a custom \f[I]node\f[].
-Any children of the node will be rendered after this text. Returns 1 on
-success 0 on failure.
+Sets the literal text to render "on enter" for a custom
+\f[I]node\f[]. Any children of the node will be rendered after
+this text. Returns 1 on success 0 on failure.
 
 .PP
 \fIconst char *\f[] \fBcmark_node_get_on_exit\f[](\fIcmark_node *node\f[])
 
 .PP
-Returns the literal "on exit" text for a custom \f[I]node\f[], or an
-empty string if no on_exit is set. Returns NULL if called on a
+Returns the literal "on exit" text for a custom \f[I]node\f[], or
+an empty string if no on_exit is set. Returns NULL if called on a
 non\-custom node.
 
 .PP
 \fIint\f[] \fBcmark_node_set_on_exit\f[](\fIcmark_node *node\f[], \fIconst char *on_exit\f[])
 
 .PP
-Sets the literal text to render "on exit" for a custom \f[I]node\f[].
-Any children of the node will be rendered before this text. Returns 1 on
-success 0 on failure.
+Sets the literal text to render "on exit" for a custom
+\f[I]node\f[]. Any children of the node will be rendered before
+this text. Returns 1 on success 0 on failure.
 
 .PP
 \fIint\f[] \fBcmark_node_get_start_line\f[](\fIcmark_node *node\f[])
@@ -595,37 +624,37 @@ Tree Manipulation
 \fIvoid\f[] \fBcmark_node_unlink\f[](\fIcmark_node *node\f[])
 
 .PP
-Unlinks a \f[I]node\f[], removing it from the tree, but not freeing its
-memory. (Use \f[I]cmark_node_free\f[] for that.)
+Unlinks a \f[I]node\f[], removing it from the tree, but not
+freeing its memory. (Use \f[I]cmark_node_free\f[] for that.)
 
 .PP
 \fIint\f[] \fBcmark_node_insert_before\f[](\fIcmark_node *node\f[], \fIcmark_node *sibling\f[])
 
 .PP
-Inserts \f[I]sibling\f[] before \f[I]node\f[]. Returns 1 on success, 0
-on failure.
+Inserts \f[I]sibling\f[] before \f[I]node\f[]. Returns 1 on
+success, 0 on failure.
 
 .PP
 \fIint\f[] \fBcmark_node_insert_after\f[](\fIcmark_node *node\f[], \fIcmark_node *sibling\f[])
 
 .PP
-Inserts \f[I]sibling\f[] after \f[I]node\f[]. Returns 1 on success, 0 on
-failure.
+Inserts \f[I]sibling\f[] after \f[I]node\f[]. Returns 1 on
+success, 0 on failure.
 
 .PP
 \fIint\f[] \fBcmark_node_replace\f[](\fIcmark_node *oldnode\f[], \fIcmark_node *newnode\f[])
 
 .PP
 Replaces \f[I]oldnode\f[] with \f[I]newnode\f[] and unlinks
-\f[I]oldnode\f[] (but does not free its memory). Returns 1 on success, 0
-on failure.
+\f[I]oldnode\f[] (but does not free its memory). Returns 1 on
+success, 0 on failure.
 
 .PP
 \fIint\f[] \fBcmark_node_prepend_child\f[](\fIcmark_node *node\f[], \fIcmark_node *child\f[])
 
 .PP
-Adds \f[I]child\f[] to the beginning of the children of \f[I]node\f[].
-Returns 1 on success, 0 on failure.
+Adds \f[I]child\f[] to the beginning of the children of
+\f[I]node\f[]. Returns 1 on success, 0 on failure.
 
 .PP
 \fIint\f[] \fBcmark_node_append_child\f[](\fIcmark_node *node\f[], \fIcmark_node *child\f[])
@@ -705,22 +734,149 @@ Feeds a string of length \f[I]len\f[] to \f[I]parser\f[].
 .PP
 Finish parsing and return a pointer to a tree of nodes.
 
+.SS
+Streaming AST API
+.PP
+The functions below let a caller obtain a usable AST
+\f[I]while\f[] feeding input incrementally \[em] without calling
+\f[C]cmark_parser_finish\f[]. The intended use case is rendering
+markdown that is itself being produced incrementally (e.g. tokens
+from a language model).
+.PP
+Two correctness guarantees apply at all times:
+.IP "1." 4
+\f[B]Convergence.\f[] For any byte prefix \f[C]B_k\f[] of the
+eventual input, the tree returned by
+\f[C]cmark_parser_snapshot\f[] after \f[C]feed(B_k)\f[] is
+structurally equivalent to what \f[C]cmark_parse_document(B_k,
+...)\f[] would have produced \[em] the same blocks, the same
+inlines, the same reference resolutions \[em] modulo the
+provisional flags described below and modulo footnote reference
+numbering, which is finalized only by
+\f[C]cmark_parser_finish\f[].
+.IP "2." 4
+\f[B]Monotonic prefix.\f[] The portion of the tree before
+\f[C]cmark_parser_commit_frontier\f[] is final. Subsequent input
+never alters committed nodes (their pointers, types, children, or
+content). The portion of the tree after the commit frontier may
+be mutated in place as later input disambiguates earlier
+interpretations (paragraph → setext heading, paragraph → table
+head, unclosed emphasis → emphasis, etc.). When this happens the
+parser rewrites nodes in place and emits change records \[em]
+pointer identity is preserved across morph.
+.PP
+Nodes that may still change carry
+\f[C]cmark_node_is_provisional() == 1\f[].
+
+.PP
+\fIint\f[] \fBcmark_node_is_provisional\f[](\fIcmark_node *node\f[])
+
+.PP
+Returns 1 if \f[C]node\f[] is provisional \[em] i.e. the parser
+may still rewrite it as more input arrives. Returns 0 for
+committed nodes and for any node in a tree obtained from
+\f[C]cmark_parser_finish\f[].
+
+.PP
+\fIcmark_node *\f[] \fBcmark_parser_snapshot\f[](\fIcmark_parser *parser\f[])
+
+.PP
+Returns the current document tree without finalizing the parser.
+The returned root is owned by the parser and remains valid until
+the next call to \f[C]cmark_parser_feed\f[],
+\f[C]cmark_parser_snapshot\f[], or \f[C]cmark_parser_finish\f[].
+.PP
+Triggers incremental inline parsing on any blocks marked dirty
+since the last snapshot, so that inlines (emphasis, code spans,
+links, etc.) are present in the returned tree \[em] including a
+tentative best\-effort interpretation of trailing unclosed
+delimiters in still\-open blocks.
+
+.PP
+\fIsize_t\f[] \fBcmark_parser_commit_frontier\f[](\fIcmark_parser *parser\f[])
+
+.PP
+Returns the byte offset into the consumed input stream before
+which the AST is committed and will not change. Always
+non\-decreasing across successive calls within one parser
+lifetime.
+
+.PP
+.nf
+\fC
+.RS 0n
+typedef struct cmark_change_iter cmark_change_iter;
+.RE
+\f[]
+.fi
+
+.PP
+Opaque iterator over change records since the last call to
+\f[C]cmark_parser_changes_since_last_snapshot\f[] (or since
+parser creation). Calling this function consumes the recorded
+events; a second immediate call returns an empty iterator.
+
+.PP
+.nf
+\fC
+.RS 0n
+typedef enum {
+  CMARK_CHANGE_NONE = 0,
+  /** A new node was attached to the tree.
+   */
+  CMARK_CHANGE_NODE_ADDED,
+  /** A node was detached and freed. The pointer in the change record is the
+   * parent of the removed node (the removed node itself is no longer valid).
+   */
+  CMARK_CHANGE_NODE_REMOVED,
+  /** A node's `type` (and possibly its `as` payload) was rewritten in place.
+   * Pointer identity preserved.
+   */
+  CMARK_CHANGE_NODE_RETYPED,
+  /** A node's textual content (for blocks: the raw `content` buffer) was
+   * appended to.
+   */
+  CMARK_CHANGE_NODE_CONTENT_UPDATED,
+  /** A node's inline children were re-parsed. Old inline children may have
+   * been replaced.
+   */
+  CMARK_CHANGE_NODE_INLINES_REPARSED,
+  /** A node's `CMARK_NODE__PROVISIONAL` flag was cleared — i.e. it is now
+   * committed.
+   */
+  CMARK_CHANGE_NODE_FINALIZED,
+} cmark_change_event;
+.RE
+\f[]
+.fi
+
+
+
+.PP
+\fIcmark_change_event\f[] \fBcmark_change_iter_next\f[](\fIcmark_change_iter *iter\f[], \fIcmark_node **out_node\f[])
+
+.PP
+Advances the iterator. On return, *out_node is the affected node
+(or its parent for REMOVED). Returns CMARK_CHANGE_NONE when
+exhausted.
+
 .PP
 \fIcmark_node *\f[] \fBcmark_parse_document\f[](\fIconst char *buffer\f[], \fIsize_t len\f[], \fIint options\f[])
 
 .PP
-Parse a CommonMark document in \f[I]buffer\f[] of length \f[I]len\f[].
-Returns a pointer to a tree of nodes. The memory allocated for the node
-tree should be released using \f[I]cmark_node_free\f[] when it is no
-longer needed.
+Parse a CommonMark document in \f[I]buffer\f[] of length
+\f[I]len\f[]. Returns a pointer to a tree of nodes. The memory
+allocated for the node tree should be released using
+\f[I]cmark_node_free\f[] when it is no longer needed.
 
 .PP
 \fIcmark_node *\f[] \fBcmark_parse_file\f[](\fIFILE *f\f[], \fIint options\f[])
 
 .PP
-Parse a CommonMark document in file \f[I]f\f[], returning a pointer to a
-tree of nodes. The memory allocated for the node tree should be released
-using \f[I]cmark_node_free\f[] when it is no longer needed.
+Parse a CommonMark document in file \f[I]f\f[], returning a
+pointer to a tree of nodes. The memory allocated for the node
+tree should be released using \f[I]cmark_node_free\f[] when it is
+no longer needed.
 
 .SS
 Rendering
@@ -729,86 +885,87 @@ Rendering
 \fIchar *\f[] \fBcmark_render_xml\f[](\fIcmark_node *root\f[], \fIint options\f[])
 
 .PP
-Render a \f[I]node\f[] tree as XML. It is the caller's responsibility to
-free the returned buffer.
+Render a \f[I]node\f[] tree as XML. It is the caller's
+responsibility to free the returned buffer.
 
 .PP
 \fIchar *\f[] \fBcmark_render_xml_with_mem\f[](\fIcmark_node *root\f[], \fIint options\f[], \fIcmark_mem *mem\f[])
 
 .PP
-As for \f[I]cmark_render_xml\f[], but specifying the allocator to use
-for the resulting string.
+As for \f[I]cmark_render_xml\f[], but specifying the allocator to
+use for the resulting string.
 
 .PP
 \fIchar *\f[] \fBcmark_render_html\f[](\fIcmark_node *root\f[], \fIint options\f[], \fIcmark_llist *extensions\f[])
 
 .PP
-Render a \f[I]node\f[] tree as an HTML fragment. It is up to the user to
-add an appropriate header and footer. It is the caller's responsibility
-to free the returned buffer.
+Render a \f[I]node\f[] tree as an HTML fragment. It is up to the
+user to add an appropriate header and footer. It is the caller's
+responsibility to free the returned buffer.
 
 .PP
 \fIchar *\f[] \fBcmark_render_html_with_mem\f[](\fIcmark_node *root\f[], \fIint options\f[], \fIcmark_llist *extensions\f[], \fIcmark_mem *mem\f[])
 
 .PP
-As for \f[I]cmark_render_html\f[], but specifying the allocator to use
-for the resulting string.
+As for \f[I]cmark_render_html\f[], but specifying the allocator
+to use for the resulting string.
 
 .PP
 \fIchar *\f[] \fBcmark_render_man\f[](\fIcmark_node *root\f[], \fIint options\f[], \fIint width\f[])
 
 .PP
-Render a \f[I]node\f[] tree as a groff man page, without the header. It
-is the caller's responsibility to free the returned buffer.
+Render a \f[I]node\f[] tree as a groff man page, without the
+header. It is the caller's responsibility to free the returned
+buffer.
 
 .PP
 \fIchar *\f[] \fBcmark_render_man_with_mem\f[](\fIcmark_node *root\f[], \fIint options\f[], \fIint width\f[], \fIcmark_mem *mem\f[])
 
 .PP
-As for \f[I]cmark_render_man\f[], but specifying the allocator to use
-for the resulting string.
+As for \f[I]cmark_render_man\f[], but specifying the allocator to
+use for the resulting string.
 
 .PP
 \fIchar *\f[] \fBcmark_render_commonmark\f[](\fIcmark_node *root\f[], \fIint options\f[], \fIint width\f[])
 
 .PP
-Render a \f[I]node\f[] tree as a commonmark document. It is the caller's
-responsibility to free the returned buffer.
+Render a \f[I]node\f[] tree as a commonmark document. It is the
+caller's responsibility to free the returned buffer.
 
 .PP
 \fIchar *\f[] \fBcmark_render_commonmark_with_mem\f[](\fIcmark_node *root\f[], \fIint options\f[], \fIint width\f[], \fIcmark_mem *mem\f[])
 
 .PP
-As for \f[I]cmark_render_commonmark\f[], but specifying the allocator to
-use for the resulting string.
+As for \f[I]cmark_render_commonmark\f[], but specifying the
+allocator to use for the resulting string.
 
 .PP
 \fIchar *\f[] \fBcmark_render_plaintext\f[](\fIcmark_node *root\f[], \fIint options\f[], \fIint width\f[])
 
 .PP
-Render a \f[I]node\f[] tree as a plain text document. It is the caller's
-responsibility to free the returned buffer.
+Render a \f[I]node\f[] tree as a plain text document. It is the
+caller's responsibility to free the returned buffer.
 
 .PP
 \fIchar *\f[] \fBcmark_render_plaintext_with_mem\f[](\fIcmark_node *root\f[], \fIint options\f[], \fIint width\f[], \fIcmark_mem *mem\f[])
 
 .PP
-As for \f[I]cmark_render_plaintext\f[], but specifying the allocator to
-use for the resulting string.
+As for \f[I]cmark_render_plaintext\f[], but specifying the
+allocator to use for the resulting string.
 
 .PP
 \fIchar *\f[] \fBcmark_render_latex\f[](\fIcmark_node *root\f[], \fIint options\f[], \fIint width\f[])
 
 .PP
-Render a \f[I]node\f[] tree as a LaTeX document. It is the caller's
-responsibility to free the returned buffer.
+Render a \f[I]node\f[] tree as a LaTeX document. It is the
+caller's responsibility to free the returned buffer.
 
 .PP
 \fIchar *\f[] \fBcmark_render_latex_with_mem\f[](\fIcmark_node *root\f[], \fIint options\f[], \fIint width\f[], \fIcmark_mem *mem\f[])
 
 .PP
-As for \f[I]cmark_render_latex\f[], but specifying the allocator to use
-for the resulting string.
+As for \f[I]cmark_render_latex\f[], but specifying the allocator
+to use for the resulting string.
 
 .SS
 Options
@@ -838,7 +995,8 @@ Options affecting rendering
 .fi
 
 .PP
-Include a \f[C]data\-sourcepos\f[] attribute on all block elements.
+Include a \f[C]data\-sourcepos\f[] attribute on all block
+elements.
 
 .PP
 .nf
@@ -862,9 +1020,9 @@ Render \f[C]softbreak\f[] elements as hard line breaks.
 .fi
 
 .PP
-\f[C]CMARK_OPT_SAFE\f[] is defined here for API compatibility, but it no
-longer has any effect. "Safe" mode is now the default: set
-\f[C]CMARK_OPT_UNSAFE\f[] to disable it.
+\f[C]CMARK_OPT_SAFE\f[] is defined here for API compatibility,
+but it no longer has any effect. "Safe" mode is now the default:
+set \f[C]CMARK_OPT_UNSAFE\f[] to disable it.
 
 .PP
 .nf
@@ -877,10 +1035,11 @@ longer has any effect. "Safe" mode is now the default: set
 
 .PP
 Render raw HTML and unsafe links (\f[C]javascript:\f[],
-\f[C]vbscript:\f[], \f[C]file:\f[], and \f[C]data:\f[], except for
-\f[C]image/png\f[], \f[C]image/gif\f[], \f[C]image/jpeg\f[], or
-\f[C]image/webp\f[] mime types). By default, raw HTML is replaced by a
-placeholder HTML comment. Unsafe links are replaced by empty strings.
+\f[C]vbscript:\f[], \f[C]file:\f[], and \f[C]data:\f[], except
+for \f[C]image/png\f[], \f[C]image/gif\f[], \f[C]image/jpeg\f[],
+or \f[C]image/webp\f[] mime types). By default, raw HTML is
+replaced by a placeholder HTML comment. Unsafe links are replaced
+by empty strings.
 
 .PP
 .nf
@@ -919,8 +1078,8 @@ Legacy option (no effect).
 .fi
 
 .PP
-Validate UTF\-8 in the input before parsing, replacing illegal sequences
-with the replacement character U+FFFD.
+Validate UTF\-8 in the input before parsing, replacing illegal
+sequences with the replacement character U+FFFD.
 
 .PP
 .nf
@@ -981,8 +1140,8 @@ Parse footnotes.
 .fi
 
 .PP
-Only parse strikethroughs if surrounded by exactly 2 tildes. Gives some
-compatibility with redcarpet.
+Only parse strikethroughs if surrounded by exactly 2 tildes.
+Gives some compatibility with redcarpet.
 
 .PP
 .nf
@@ -994,7 +1153,8 @@ compatibility with redcarpet.
 .fi
 
 .PP
-Use style attributes to align table cells instead of align attributes.
+Use style attributes to align table cells instead of align
+attributes.
 
 .PP
 .nf
@@ -1006,8 +1166,8 @@ Use style attributes to align table cells instead of align attributes.
 .fi
 
 .PP
-Include the remainder of the info string in code blocks in a separate
-attribute.
+Include the remainder of the info string in code blocks in a
+separate attribute.
 
 .SS
 Version information
@@ -1016,8 +1176,8 @@ Version information
 \fIint\f[] \fBcmark_version\f[](\fIvoid\f[])
 
 .PP
-The library version as integer for runtime checks. Also available as
-macro CMARK_VERSION for compile time checks.
+The library version as integer for runtime checks. Also available
+as macro CMARK_VERSION for compile time checks.
 .IP \[bu] 2
 Bits 16\-23 contain the major version.
 .IP \[bu] 2
@@ -1025,14 +1185,15 @@ Bits 8\-15 contain the minor version.
 .IP \[bu] 2
 Bits 0\-7 contain the patchlevel.
 .PP
-In hexadecimal format, the number 0x010203 represents version 1.2.3.
+In hexadecimal format, the number 0x010203 represents
+version 1.2.3.
 
 .PP
 \fIconst char *\f[] \fBcmark_version_string\f[](\fIvoid\f[])
 
 .PP
-The library version string for runtime checks. Also available as macro
-CMARK_VERSION_STRING for compile time checks.
+The library version string for runtime checks. Also available as
+macro CMARK_VERSION_STRING for compile time checks.
 
 .SH
 AUTHORS

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,7 @@ set(HEADERS
   cmark_ctype.h
   render.h
   registry.h
+  streaming.h
   syntax_extension.h
   plugin.h
   )
@@ -53,6 +54,7 @@ set(LIBRARY_SOURCES
   cmark_ctype.c
   arena.c
   linked_list.c
+  streaming.c
   syntax_extension.c
   registry.c
   plugin.c

--- a/src/blocks.c
+++ b/src/blocks.c
@@ -23,6 +23,7 @@
 #include "houdini.h"
 #include "buffer.h"
 #include "footnotes.h"
+#include "streaming.h"
 
 #define CODE_INDENT 4
 #define TAB_STOP 4
@@ -116,6 +117,8 @@ static void cmark_parser_dispose(cmark_parser *parser) {
 
   if (parser->refmap)
     cmark_map_free(parser->refmap);
+
+  cmark_streaming_state_free(parser->mem, &parser->streaming);
 }
 
 static void cmark_parser_reset(cmark_parser *parser) {
@@ -141,6 +144,8 @@ static void cmark_parser_reset(cmark_parser *parser) {
   parser->syntax_extensions = saved_exts;
   parser->inline_syntax_extensions = saved_inline_exts;
   parser->options = saved_options;
+
+  cmark_streaming_state_init(&parser->streaming);
 }
 
 cmark_parser *cmark_parser_new_with_mem(int options, cmark_mem *mem) {
@@ -167,6 +172,7 @@ void cmark_parser_free(cmark_parser *parser) {
 }
 
 static cmark_node *finalize(cmark_parser *parser, cmark_node *b);
+static void try_eager_ref_extract(cmark_parser *parser, cmark_node *p);
 
 // Returns true if line has only space characters, else false.
 static bool is_blank(cmark_strbuf *s, bufsize_t offset) {
@@ -218,6 +224,19 @@ static void add_line(cmark_node *node, cmark_chunk *ch, cmark_parser *parser) {
   }
   cmark_strbuf_put(&node->content, ch->data + parser->offset,
                    ch->len - parser->offset);
+
+  // Streaming: try to extract any leading ref-defs that are now complete
+  // and bounded. This populates the refmap as soon as possible — without
+  // waiting for the paragraph to close — which is what lets earlier blocks
+  // with [foo] references resolve to LINK on the next snapshot.
+  try_eager_ref_extract(parser, node);
+
+  // Streaming: queue this block for snapshot processing. The handler
+  // (cmark_streaming_run_pending_inlines) decides per block whether to emit
+  // INLINES_REPARSED (for inline-bearing blocks) or CONTENT_UPDATED (for
+  // code/html and other literal blocks). The dirty-mark is idempotent — at
+  // most one record per block per snapshot.
+  cmark_streaming_mark_inline_dirty(parser, node);
 }
 
 static void remove_trailing_blank_lines(cmark_strbuf *ln) {
@@ -280,6 +299,62 @@ static bool resolve_reference_link_definitions(
   return !is_blank(&b->content, 0);
 }
 
+// Streaming: attempt to extract leading [label]: url ["title"] reference
+// definitions from a paragraph's content as soon as we can prove the def is
+// bounded — i.e., before the paragraph closes.
+//
+// Why this is needed: in standard cmark, ref-defs are extracted only when
+// their host paragraph finalizes. For incremental input that's a problem:
+// a [foo] reference earlier in the document stays as plain text until the
+// trailing def-paragraph closes (typically requiring a following blank line
+// the user may not have fed yet). Eager extraction lets the def populate
+// the refmap as soon as it is unambiguously complete.
+//
+// Why it must be careful: the title can extend onto the next line (CommonMark
+// permits [foo]: url\n   "title"\n). If we extract a def at the moment we
+// see [foo]: url\n and the next bytes turn out to be    "title"\n, we
+// have committed a different AST than one-shot parse would have produced —
+// a contract violation.
+//
+// Safety rule: a leading def is committable iff the first byte after its
+// parsed extent is non-whitespace. Reasoning:
+//   - whitespace at that byte could be the leading indent of a title-bearing
+//     continuation line; defer until the next byte arrives;
+//   - a non-whitespace byte means any title would have had to start on the
+//     def line itself (already considered by the parser) and didn't, so the
+//     def is final and the trailing content belongs to a subsequent block.
+static void try_eager_ref_extract(cmark_parser *parser, cmark_node *p) {
+  if (S_type(p) != CMARK_NODE_PARAGRAPH)
+    return;
+  cmark_strbuf *node_content = &p->content;
+  bufsize_t cursor = 0;
+  while (cursor < node_content->size && node_content->ptr[cursor] == '[') {
+    cmark_chunk dryrun = {node_content->ptr + cursor,
+                           node_content->size - cursor, 0};
+    bufsize_t parsed_len = cmark_parse_reference_inline(parser->mem, &dryrun,
+                                                        /*refmap=*/NULL);
+    if (parsed_len == 0)
+      break;
+    // Safety: can we prove the def is bounded?
+    bufsize_t next_byte_offset = cursor + parsed_len;
+    if (next_byte_offset >= node_content->size)
+      break;  // No bytes after — title might still extend the def.
+    unsigned char next_byte = node_content->ptr[next_byte_offset];
+    if (next_byte == ' ' || next_byte == '\t')
+      break;  // Whitespace lead-in — could be a title-continuation line.
+    // Bounded: commit.
+    cmark_chunk commit = {node_content->ptr + cursor,
+                           node_content->size - cursor, 0};
+    cmark_parse_reference_inline(parser->mem, &commit, parser->refmap);
+    cursor = next_byte_offset;
+  }
+  if (cursor > 0) {
+    cmark_strbuf_drop(node_content, cursor);
+    // Re-attempting from new content start in a future call is correct —
+    // we always loop from byte 0 of node_content.
+  }
+}
+
 static cmark_node *finalize(cmark_parser *parser, cmark_node *b) {
   bufsize_t pos;
   cmark_node *item;
@@ -318,7 +393,13 @@ static cmark_node *finalize(cmark_parser *parser, cmark_node *b) {
     has_content = resolve_reference_link_definitions(parser, b);
     if (!has_content) {
       // remove blank node (former reference def)
+      // Streaming: the paragraph turned out to be only reference defs and
+      // is being deleted. Emit a NODE_REMOVED record with the parent, since
+      // the node pointer is about to be invalid.
+      cmark_streaming_record(parser, CMARK_CHANGE_NODE_REMOVED, parent);
       cmark_node_free(b);
+      // Skip the FINALIZED tail-emit below — node is gone.
+      return parent;
     }
     break;
   }
@@ -387,6 +468,14 @@ static cmark_node *finalize(cmark_parser *parser, cmark_node *b) {
     break;
   }
 
+  // Streaming: clear the provisional flag and announce that this block is
+  // now committed. We skip DOCUMENT to mirror the policy in add_child.
+  if (S_type(b) != CMARK_NODE_DOCUMENT &&
+      (b->flags & CMARK_NODE__PROVISIONAL)) {
+    b->flags &= ~CMARK_NODE__PROVISIONAL;
+    cmark_streaming_record(parser, CMARK_CHANGE_NODE_FINALIZED, b);
+  }
+
   return parent;
 }
 
@@ -413,6 +502,14 @@ static cmark_node *add_child(cmark_parser *parser, cmark_node *parent,
     child->prev = NULL;
   }
   parent->last_child = child;
+
+  // Streaming: every newly opened block is provisional until finalized.
+  // The DOCUMENT root is the parser-internal frame and never carries the
+  // flag — it is created in cmark_parser_reset, before the streaming state
+  // exists, and never represents user-visible content directly.
+  child->flags |= CMARK_NODE__PROVISIONAL;
+  cmark_streaming_record(parser, CMARK_CHANGE_NODE_ADDED, child);
+
   return child;
 }
 
@@ -434,6 +531,12 @@ void cmark_manage_extensions_special_characters(cmark_parser *parser, int add) {
 
 // Walk through node and all children, recursively, parsing
 // string content into inline content where appropriate.
+//
+// Streaming: blocks whose inline content has already been parsed by
+// cmark_parser_snapshot — and not modified since — are skipped. The
+// indicator is `inline_parsed_len == content.size && !INLINE_DIRTY`. New
+// content arriving via add_line resets INLINE_DIRTY, so this skip only
+// fires for genuinely up-to-date subtrees.
 static void process_inlines(cmark_parser *parser,
                             cmark_map *refmap, int options) {
   cmark_iter *iter = cmark_iter_new(parser->root);
@@ -446,7 +549,20 @@ static void process_inlines(cmark_parser *parser,
     cur = cmark_iter_get_node(iter);
     if (ev_type == CMARK_EVENT_ENTER) {
       if (contains_inlines(cur)) {
-        cmark_parse_inlines(parser, cur, refmap, options);
+        bool already_parsed =
+            !(cur->flags & CMARK_NODE__INLINE_DIRTY) &&
+            cur->inline_parsed_len == cur->content.size &&
+            cur->content.size > 0;
+        if (!already_parsed) {
+          // Streaming may have produced inline children at an earlier
+          // snapshot; drop them so this re-parse is the authoritative one.
+          while (cur->first_child) {
+            cmark_node_free(cur->first_child);
+          }
+          cmark_parse_inlines(parser, cur, refmap, options);
+          cur->inline_parsed_len = cur->content.size;
+          cur->flags &= ~CMARK_NODE__INLINE_DIRTY;
+        }
       }
     }
   }
@@ -694,7 +810,14 @@ cmark_node *cmark_parse_document(const char *buffer, size_t len, int options) {
 }
 
 void cmark_parser_feed(cmark_parser *parser, const char *buffer, size_t len) {
+  // Streaming: mark this parser active for the duration of the call so that
+  // mutation primitives invoked during parsing can find it (see streaming.h).
+  // We restore the prior value rather than nulling, because parsers can call
+  // each other reentrantly via cmark_parser_feed_reentrant.
+  cmark_parser *prev = cmark_streaming_active_parser();
+  cmark_streaming_set_active_parser(parser);
   S_parser_feed(parser, (const unsigned char *)buffer, len, false);
+  cmark_streaming_set_active_parser(prev);
 }
 
 void cmark_parser_feed_reentrant(cmark_parser *parser, const char *buffer, size_t len) {
@@ -704,7 +827,10 @@ void cmark_parser_feed_reentrant(cmark_parser *parser, const char *buffer, size_
   cmark_strbuf_puts(&saved_linebuf, cmark_strbuf_cstr(&parser->linebuf));
   cmark_strbuf_clear(&parser->linebuf);
 
+  cmark_parser *prev = cmark_streaming_active_parser();
+  cmark_streaming_set_active_parser(parser);
   S_parser_feed(parser, (const unsigned char *)buffer, len, true);
+  cmark_streaming_set_active_parser(prev);
 
   cmark_strbuf_sets(&parser->linebuf, cmark_strbuf_cstr(&saved_linebuf));
   cmark_strbuf_free(&saved_linebuf);
@@ -719,6 +845,12 @@ static void S_parser_feed(cmark_parser *parser, const unsigned char *buffer,
     parser->total_size = UINT_MAX;
   else
     parser->total_size += len;
+
+  // Streaming: account for bytes that are now part of the consumed input.
+  // The commit frontier is a subset of total_consumed_bytes — see
+  // streaming.h. This advances unconditionally; the frontier itself is
+  // advanced at block-finalization points.
+  cmark_streaming_advance_consumed(parser, len);
 
   if (parser->last_buffer_ended_with_cr && *buffer == '\n') {
     // skip NL if last buffer ended with CR ; see #117
@@ -743,7 +875,16 @@ static void S_parser_feed(cmark_parser *parser, const unsigned char *buffer,
     }
 
     chunk_len = (bufsize_t)(eol - buffer);
+    // Streaming: capture the byte-size of any carryover buffered from a
+    // prior feed BEFORE we mutate linebuf. Used below to advance the
+    // line-start map.
+    bufsize_t carryover = parser->linebuf.size;
     if (process) {
+      // Streaming: record where this line started in the global input
+      // stream. parser->streaming.current_line_start_byte was set when the
+      // previous line ended (or 0 at parser creation).
+      cmark_streaming_record_line_start(parser,
+                                        parser->streaming.current_line_start_byte);
       if (parser->linebuf.size > 0) {
         cmark_strbuf_put(&parser->linebuf, buffer, chunk_len);
         S_process_line(parser, parser->linebuf.ptr, parser->linebuf.size);
@@ -763,20 +904,36 @@ static void S_parser_feed(cmark_parser *parser, const unsigned char *buffer,
     }
 
     buffer += chunk_len;
+    bufsize_t line_ending_bytes = 0;
     if (buffer < end) {
       if (*buffer == '\0') {
         // skip over NULL
         buffer++;
+        line_ending_bytes++;
       } else {
         // skip over line ending characters
         if (*buffer == '\r') {
           buffer++;
+          line_ending_bytes++;
           if (buffer == end)
             parser->last_buffer_ended_with_cr = true;
         }
-        if (buffer < end && *buffer == '\n')
+        if (buffer < end && *buffer == '\n') {
           buffer++;
+          line_ending_bytes++;
+        }
       }
+    }
+
+    // Streaming: advance the in-progress-line cursor. If we just processed
+    // a complete line, current_line_start_byte moves to the start of the
+    // NEXT line (= carryover + this chunk + line ending). If we only
+    // buffered a partial line, the start doesn't move (we're still
+    // accumulating bytes for the same line).
+    if (process) {
+      parser->streaming.current_line_start_byte +=
+          (size_t)carryover + (size_t)chunk_len + (size_t)line_ending_bytes;
+      cmark_streaming_recompute_frontier(parser);
     }
   }
 }
@@ -1203,7 +1360,11 @@ static void open_new_blocks(cmark_parser *parser, cmark_node **container,
 
       if (has_content) {
 
-        (*container)->type = (uint16_t)CMARK_NODE_HEADING;
+        // Rewrite the paragraph in place. Going through cmark_node_set_type
+        // (rather than a direct type assignment) routes the rewrite through
+        // the streaming event stream: pointer identity is preserved, and a
+        // RETYPED record is emitted for any active snapshot consumer.
+        cmark_node_set_type(*container, CMARK_NODE_HEADING);
         (*container)->as.heading.level = lev;
         (*container)->as.heading.setext = true;
         S_advance_offset(parser, input, input->len - 1 - parser->offset, false);
@@ -1520,10 +1681,15 @@ finished:
 cmark_node *cmark_parser_finish(cmark_parser *parser) {
   cmark_node *res;
   cmark_llist *extensions;
+  cmark_parser *prev_active;
 
   /* Parser was already finished once */
   if (parser->root == NULL)
     return NULL;
+
+  // Streaming: see comment in cmark_parser_feed for rationale.
+  prev_active = cmark_streaming_active_parser();
+  cmark_streaming_set_active_parser(parser);
 
   if (parser->linebuf.size) {
     S_process_line(parser, parser->linebuf.ptr, parser->linebuf.size);
@@ -1556,6 +1722,8 @@ cmark_node *cmark_parser_finish(cmark_parser *parser) {
   parser->root = NULL;
 
   cmark_parser_reset(parser);
+
+  cmark_streaming_set_active_parser(prev_active);
 
   return res;
 }

--- a/src/cmark-gfm.h
+++ b/src/cmark-gfm.h
@@ -594,6 +594,109 @@ void cmark_parser_feed(cmark_parser *parser, const char *buffer, size_t len);
 CMARK_GFM_EXPORT
 cmark_node *cmark_parser_finish(cmark_parser *parser);
 
+/**
+ * ## Streaming AST API
+ *
+ * The functions below let a caller obtain a usable AST *while* feeding input
+ * incrementally — without calling `cmark_parser_finish`. The intended use case
+ * is rendering markdown that is itself being produced incrementally (e.g.
+ * tokens from a language model).
+ *
+ * Two correctness guarantees apply at all times:
+ *
+ *   1. **Convergence.** For any byte prefix `B_k` of the eventual input, the
+ *      tree returned by `cmark_parser_snapshot` after `feed(B_k)` is
+ *      structurally equivalent to what `cmark_parse_document(B_k, ...)` would
+ *      have produced — the same blocks, the same inlines, the same reference
+ *      resolutions — modulo the provisional flags described below and modulo
+ *      footnote reference numbering, which is finalized only by
+ *      `cmark_parser_finish`.
+ *
+ *   2. **Monotonic prefix.** The portion of the tree before
+ *      `cmark_parser_commit_frontier` is final. Subsequent input never alters
+ *      committed nodes (their pointers, types, children, or content). The
+ *      portion of the tree after the commit frontier may be mutated in place
+ *      as later input disambiguates earlier interpretations (paragraph →
+ *      setext heading, paragraph → table head, unclosed emphasis → emphasis,
+ *      etc.). When this happens the parser rewrites nodes in place and emits
+ *      change records — pointer identity is preserved across morph.
+ *
+ * Nodes that may still change carry `cmark_node_is_provisional() == 1`.
+ */
+
+/** Returns 1 if `node` is provisional — i.e. the parser may still rewrite it
+ * as more input arrives. Returns 0 for committed nodes and for any node in a
+ * tree obtained from `cmark_parser_finish`.
+ */
+CMARK_GFM_EXPORT
+int cmark_node_is_provisional(cmark_node *node);
+
+/** Returns the current document tree without finalizing the parser. The
+ * returned root is owned by the parser and remains valid until the next call
+ * to `cmark_parser_feed`, `cmark_parser_snapshot`, or `cmark_parser_finish`.
+ *
+ * Triggers incremental inline parsing on any blocks marked dirty since the
+ * last snapshot, so that inlines (emphasis, code spans, links, etc.) are
+ * present in the returned tree — including a tentative best-effort
+ * interpretation of trailing unclosed delimiters in still-open blocks.
+ */
+CMARK_GFM_EXPORT
+cmark_node *cmark_parser_snapshot(cmark_parser *parser);
+
+/** Returns the byte offset into the consumed input stream before which the
+ * AST is committed and will not change. Always non-decreasing across
+ * successive calls within one parser lifetime.
+ */
+CMARK_GFM_EXPORT
+size_t cmark_parser_commit_frontier(cmark_parser *parser);
+
+/** Opaque iterator over change records since the last call to
+ * `cmark_parser_changes_since_last_snapshot` (or since parser creation).
+ * Calling this function consumes the recorded events; a second immediate call
+ * returns an empty iterator.
+ */
+typedef struct cmark_change_iter cmark_change_iter;
+
+typedef enum {
+  CMARK_CHANGE_NONE = 0,
+  /** A new node was attached to the tree.
+   */
+  CMARK_CHANGE_NODE_ADDED,
+  /** A node was detached and freed. The pointer in the change record is the
+   * parent of the removed node (the removed node itself is no longer valid).
+   */
+  CMARK_CHANGE_NODE_REMOVED,
+  /** A node's `type` (and possibly its `as` payload) was rewritten in place.
+   * Pointer identity preserved.
+   */
+  CMARK_CHANGE_NODE_RETYPED,
+  /** A node's textual content (for blocks: the raw `content` buffer) was
+   * appended to.
+   */
+  CMARK_CHANGE_NODE_CONTENT_UPDATED,
+  /** A node's inline children were re-parsed. Old inline children may have
+   * been replaced.
+   */
+  CMARK_CHANGE_NODE_INLINES_REPARSED,
+  /** A node's `CMARK_NODE__PROVISIONAL` flag was cleared — i.e. it is now
+   * committed.
+   */
+  CMARK_CHANGE_NODE_FINALIZED,
+} cmark_change_event;
+
+CMARK_GFM_EXPORT
+cmark_change_iter *cmark_parser_changes_since_last_snapshot(cmark_parser *parser);
+
+/** Advances the iterator. On return, *out_node is the affected node (or its
+ * parent for REMOVED). Returns CMARK_CHANGE_NONE when exhausted.
+ */
+CMARK_GFM_EXPORT
+cmark_change_event cmark_change_iter_next(cmark_change_iter *iter,
+                                         cmark_node **out_node);
+
+CMARK_GFM_EXPORT
+void cmark_change_iter_free(cmark_change_iter *iter);
+
 /** Parse a CommonMark document in 'buffer' of length 'len'.
  * Returns a pointer to a tree of nodes.  The memory allocated for
  * the node tree should be released using 'cmark_node_free'

--- a/src/inlines.c
+++ b/src/inlines.c
@@ -12,6 +12,7 @@
 #include "utf8.h"
 #include "scanners.h"
 #include "inlines.h"
+#include "streaming.h"
 #include "syntax_extension.h"
 
 static const char *EMDASH = "\xE2\x80\x94";
@@ -63,6 +64,11 @@ typedef struct subject{
   bufsize_t backticks[MAXBACKTICKS + 1];
   bool scanned_for_backticks;
   bool no_link_openers;
+  // Streaming: the block whose content this subject is parsing. Used to
+  // register pending-ref entries when an unresolved [label] is seen, so the
+  // block can be re-parsed once the definition arrives. NULL means "don't
+  // track" — preserves backwards-compatibility with non-streaming callers.
+  cmark_node *block;
 } subject;
 
 // Extensions may populate this.
@@ -200,6 +206,7 @@ static void subject_from_buf(cmark_mem *mem, int line_number, int block_offset, 
   }
   e->scanned_for_backticks = false;
   e->no_link_openers = true;
+  e->block = NULL;
 }
 
 static CMARK_INLINE int isbacktick(int c) { return (c == '`'); }
@@ -1222,6 +1229,16 @@ static cmark_node *handle_close_bracket(cmark_parser *parser, subject *subj) {
 
   if (found_label) {
     ref = (cmark_reference *)cmark_map_lookup(subj->refmap, &raw_label);
+    // Streaming: if the lookup missed, the block we're parsing depends on a
+    // definition that hasn't arrived yet. Register it so the block is
+    // marked inline-dirty when the def comes in (see streaming.c). The
+    // helper copies raw_label, so it's safe to free below.
+    if (!ref && subj->block) {
+      cmark_parser *active = cmark_streaming_active_parser();
+      if (active && active->refmap == subj->refmap) {
+        cmark_streaming_add_pending_ref(active, raw_label, subj->block);
+      }
+    }
     cmark_chunk_free(subj->mem, &raw_label);
   }
 
@@ -1537,10 +1554,33 @@ void cmark_parse_inlines(cmark_parser *parser,
   subject subj;
   cmark_chunk content = {parent->content.ptr, parent->content.size, 0};
   subject_from_buf(parser->mem, parent->start_line, parent->start_column - 1 + parent->internal_offset, &subj, &content, refmap);
+  // Streaming: tell the inline parser which block it's working on, so it
+  // can register pending-ref users when [label] lookups miss.
+  subj.block = parent;
   cmark_chunk_rtrim(&subj.input);
 
   while (!is_eof(&subj) && parse_inline(parser, &subj, parent, options))
     ;
+
+  // Streaming: if the block is still open, every delimiter / bracket on the
+  // stack at end-of-content is a candidate opener whose closer might yet
+  // arrive. Mark its in-tree inline text node as INLINE_PROVISIONAL BEFORE
+  // process_emphasis runs — that function (a) frees the inl_text of
+  // delimiters it matches into emphasis (so the flag dies naturally with the
+  // node), and (b) drains the stack on its way out, so any after-the-fact
+  // walk would be empty. For a closed block we leave the flag off — leftover
+  // openers in a closed block are truly literal text.
+  bool block_open = parent && (parent->flags & CMARK_NODE__OPEN);
+  if (block_open) {
+    for (delimiter *d = subj.last_delim; d != NULL; d = d->previous) {
+      if (d->inl_text)
+        d->inl_text->flags |= CMARK_NODE__INLINE_PROVISIONAL;
+    }
+    for (bracket *b = subj.last_bracket; b != NULL; b = b->previous) {
+      if (b->inl_text)
+        b->inl_text->flags |= CMARK_NODE__INLINE_PROVISIONAL;
+    }
+  }
 
   process_emphasis(parser, &subj, 0);
   // free bracket and delim stack
@@ -1621,8 +1661,15 @@ bufsize_t cmark_parse_reference_inline(cmark_mem *mem, cmark_chunk *input,
       return 0;
     }
   }
-  // insert reference into refmap
-  cmark_reference_create(refmap, &lab, &url, &title);
+  // Streaming: a NULL refmap is a "dry run" — return the parsed length
+  // without committing to any map. Used by the eager-extract path in
+  // add_line to test whether the content currently spells a complete def
+  // before deciding whether it is safe to commit (no title-continuation
+  // could still extend it). All chunks parsed above are alloc=0 views into
+  // subj.input, so skipping the create call leaks nothing.
+  if (refmap != NULL) {
+    cmark_reference_create(refmap, &lab, &url, &title);
+  }
   return subj.pos;
 }
 

--- a/src/map.c
+++ b/src/map.c
@@ -51,8 +51,22 @@ refsearch(const void *label, const void *p2) {
 }
 
 static void sort_map(cmark_map *map) {
-  size_t i = 0, last = 0, size = map->size;
+  size_t i = 0, last = 0;
   cmark_map_entry *r = map->refs, **sorted = NULL;
+
+  // Count the actual list length. We can't trust map->size here: a previous
+  // sort_map run may have stored the post-dedup count there, and streaming
+  // re-sorts (after refs are added between lookups) need the true length to
+  // size the allocation correctly.
+  size_t size = 0;
+  for (cmark_map_entry *q = map->refs; q; q = q->next)
+    size++;
+
+  if (size == 0) {
+    map->sorted = NULL;
+    map->size = 0;
+    return;
+  }
 
   sorted = (cmark_map_entry **)map->mem->calloc(size, sizeof(cmark_map_entry *));
   while (r) {

--- a/src/node.c
+++ b/src/node.c
@@ -3,6 +3,7 @@
 
 #include "config.h"
 #include "node.h"
+#include "streaming.h"
 #include "syntax_extension.h"
 
 /**
@@ -233,6 +234,34 @@ int cmark_node_set_type(cmark_node * node, cmark_node_type type) {
 
   node->type = (uint16_t)type;
 
+  // If the new type cannot contain some of the existing children (e.g.
+  // paragraph -> table: inline TEXT children are not valid table content),
+  // free those children. This makes set_type safe to call even when the
+  // source type was already populated by a streaming inline-parse pass.
+  {
+    cmark_node *child = node->first_child;
+    while (child) {
+      cmark_node *next = child->next;
+      if (!cmark_node_can_contain_type(node, (cmark_node_type)child->type)) {
+        cmark_node_free(child);
+      }
+      child = next;
+    }
+  }
+
+  // Streaming: if a parser is currently driving this thread, the in-place
+  // type change is part of incremental disambiguation (e.g. paragraph ->
+  // setext heading, paragraph -> table). Emit a change event so
+  // consumers of cmark_parser_changes_since_last_snapshot can see the
+  // rewrite. Pointer identity is preserved by design — that's the whole
+  // point of using set_type rather than replacing the node.
+  {
+    cmark_parser *active = cmark_streaming_active_parser();
+    if (active) {
+      cmark_streaming_record(active, CMARK_CHANGE_NODE_RETYPED, node);
+    }
+  }
+
   return 1;
 }
 
@@ -421,6 +450,17 @@ const char *cmark_node_get_string_content(cmark_node *node) {
 
 int cmark_node_set_string_content(cmark_node *node, const char *content) {
   cmark_strbuf_sets(&node->content, content);
+  // Streaming: mark inline state stale so it is re-parsed on the next
+  // snapshot/finalize. Used by extensions (e.g. table cells written via
+  // this entry point). The contains_inlines mirror lives on extensions or
+  // the core block-type set; we conservatively mark and let the inline-run
+  // pass decide whether re-parse is meaningful.
+  {
+    cmark_parser *active = cmark_streaming_active_parser();
+    if (active) {
+      cmark_streaming_mark_inline_dirty(active, node);
+    }
+  }
   return true;
 }
 

--- a/src/node.h
+++ b/src/node.h
@@ -53,9 +53,28 @@ enum cmark_node__internal_flags {
   CMARK_NODE__LAST_LINE_BLANK = (1 << 1),
   CMARK_NODE__LAST_LINE_CHECKED = (1 << 2),
 
+  /**
+   * Streaming: this block/inline node is provisional and may still be
+   * rewritten by future input. Cleared when the parser commits the node.
+   */
+  CMARK_NODE__PROVISIONAL = (1 << 3),
+
+  /**
+   * Streaming (inline): this inline node represents an as-yet-unmatched
+   * delimiter (e.g. a trailing * or [ whose closer has not arrived).
+   * Renderers should treat it as tentatively literal.
+   */
+  CMARK_NODE__INLINE_PROVISIONAL = (1 << 4),
+
+  /**
+   * Streaming: this block's inline content is dirty and must be re-parsed
+   * on the next snapshot. Internal use only.
+   */
+  CMARK_NODE__INLINE_DIRTY = (1 << 5),
+
   // Extensions can register custom flags by calling `cmark_register_node_flag`.
   // This is the starting value for the custom flags.
-  CMARK_NODE__REGISTER_FIRST = (1 << 3),
+  CMARK_NODE__REGISTER_FIRST = (1 << 6),
 };
 
 typedef uint16_t cmark_node_internal_flags;
@@ -108,6 +127,19 @@ struct cmark_node {
     int cell_index; // For keeping track of TABLE_CELL table alignments
     void *opaque;
   } as;
+
+  /**
+   * Streaming: bytes of `content` already consumed by the most recent
+   * incremental inline parse. 0 means "never parsed" (the natural calloc
+   * value used by make_block). Internal use only.
+   */
+  bufsize_t inline_parsed_len;
+
+  /**
+   * Streaming: intrusive next-pointer for the parser's dirty-block list.
+   * NULL when not on the list. Internal use only.
+   */
+  struct cmark_node *dirty_next;
 };
 
 /**

--- a/src/parser.h
+++ b/src/parser.h
@@ -12,6 +12,72 @@ extern "C" {
 
 #define MAX_LINK_LABEL_LENGTH 1000
 
+/* Forward declaration for the streaming event record; defined in streaming.c. */
+struct cmark_change_record;
+
+/**
+ * Per-parser streaming state. Aggregated here (not allocated separately) to
+ * keep cache locality with the rest of the parser. All fields are zero-init
+ * compatible — a parser that never calls snapshot() pays only the storage
+ * cost.
+ */
+struct cmark_parser_streaming_state {
+  /**
+   * Byte offset into the consumed input stream before which the AST is
+   * committed (no future input can rewrite it). 0 at construction.
+   */
+  size_t commit_frontier;
+  /* Total bytes accepted by feed() so far. commit_frontier <= total. */
+  size_t total_consumed_bytes;
+  /**
+   * Byte offset where the line currently being assembled (in linebuf) started
+   * in the global input stream. Equals total_consumed_bytes when there is no
+   * in-progress line.
+   */
+  size_t current_line_start_byte;
+  /**
+   * Map from line number to byte offset of that line's start.
+   * line_start_bytes[k-1] = byte offset where line k starts (1-indexed lines).
+   * Grown lazily by S_parser_feed each time a line is processed.
+   */
+  size_t *line_start_bytes;
+  size_t line_start_bytes_len;
+  size_t line_start_bytes_cap;
+  /**
+   * The last document child whose subtree is fully committed in the frontier
+   * computation. Subsequent recompute_frontier calls start from this node's
+   * `next` rather than walking the whole prefix every time. NULL when no
+   * children are yet committed. Cleared on parser_reset.
+   */
+  struct cmark_node *frontier_last_committed_child;
+  /* Singly-linked stream of change events since last snapshot consumption. */
+  struct cmark_change_record *events_head;
+  struct cmark_change_record *events_tail;
+  /**
+   * Head of the intrusive dirty-block list (linked via cmark_node.dirty_next).
+   * Blocks are appended when their content changes and drained on snapshot.
+   */
+  struct cmark_node *dirty_blocks_head;
+  /**
+   * Reverse index: link reference labels that have been seen as `[ref]`-style
+   * uses but whose definitions are not yet in refmap. Linked list of
+   * {label_chunk, user_block} pairs. Drained when a definition arrives, marking
+   * the user block inline-dirty for re-parse.
+   */
+  struct cmark_pending_ref_user *pending_ref_users_head;
+  /**
+   * Generation counter incremented on each snapshot — used for cheap "is this
+   * event record stale" checks if the consumer skips snapshots.
+   */
+  uint32_t snapshot_generation;
+};
+
+struct cmark_pending_ref_user {
+  cmark_chunk label;
+  struct cmark_node *user_block;
+  struct cmark_pending_ref_user *next;
+};
+
 struct cmark_parser {
   struct cmark_mem *mem;
   /* A hashtable of urls in the current document for cross-references */
@@ -50,6 +116,8 @@ struct cmark_parser {
   cmark_llist *syntax_extensions;
   cmark_llist *inline_syntax_extensions;
   cmark_ispunct_func backslash_ispunct;
+  /* Streaming AST state. Always present; quiescent unless snapshot() is used. */
+  struct cmark_parser_streaming_state streaming;
 };
 
 #ifdef __cplusplus

--- a/src/references.c
+++ b/src/references.c
@@ -3,6 +3,7 @@
 #include "references.h"
 #include "inlines.h"
 #include "chunk.h"
+#include "streaming.h"
 
 static void reference_free(cmark_map *map, cmark_map_entry *_ref) {
   cmark_reference *ref = (cmark_reference *)_ref;
@@ -24,7 +25,14 @@ void cmark_reference_create(cmark_map *map, cmark_chunk *label,
   if (reflabel == NULL)
     return;
 
-  assert(map->sorted == NULL);
+  // Streaming: refs may be added after a previous lookup has populated the
+  // sorted-index cache (this never happened in batch mode, where defs were
+  // fully discovered before any inline parsing). Invalidate the cache so
+  // the next lookup re-sorts and observes the new entry.
+  if (map->sorted) {
+    map->mem->free(map->sorted);
+    map->sorted = NULL;
+  }
 
   ref = (cmark_reference *)map->mem->calloc(1, sizeof(*ref));
   ref->entry.label = reflabel;
@@ -36,6 +44,17 @@ void cmark_reference_create(cmark_map *map, cmark_chunk *label,
 
   map->refs = (cmark_map_entry *)ref;
   map->size++;
+
+  // Streaming: notify any blocks that previously failed to resolve this
+  // label so they get re-parsed on the next snapshot. We cross-check that
+  // the active parser owns this map — public callers may operate on a
+  // standalone map outside any parser context.
+  {
+    cmark_parser *active = cmark_streaming_active_parser();
+    if (active && active->refmap == map) {
+      cmark_streaming_resolve_pending_refs(active, *label);
+    }
+  }
 }
 
 cmark_map *cmark_reference_map_new(cmark_mem *mem) {

--- a/src/streaming.c
+++ b/src/streaming.c
@@ -1,0 +1,423 @@
+// Streaming AST support for cmark-gfm.
+//
+// Provides incremental snapshots of the parse tree while feed() is in
+// progress, plus a stream of change events for in-place rewrites (paragraph -> setext,
+// paragraph -> table, ref-link resolution, etc.). See cmark-gfm.h for the
+// public contract and project_streaming_ast.md for design notes.
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "cmark-gfm.h"
+#include "inlines.h"
+#include "map.h"
+#include "node.h"
+#include "parser.h"
+#include "streaming.h"
+#include "syntax_extension.h"
+
+// The opaque iterator type announced in the public header.
+struct cmark_change_iter {
+  cmark_mem *mem;
+  struct cmark_change_record *head;    // still-to-yield records
+  struct cmark_change_record *to_free; // full chain head, freed on _free
+};
+
+// Thread-local active-parser pointer. Lets node mutation primitives (which
+// have public, parser-less signatures) emit change events when running
+// inside cmark_parser_feed / cmark_parser_finish. Falls back to plain static
+// if neither C11 threads nor a compiler thread-local extension is available
+// (single-threaded build).
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L && \
+    !defined(__STDC_NO_THREADS__)
+  static _Thread_local cmark_parser *s_active_parser;
+#elif defined(__GNUC__) || defined(__clang__)
+  static __thread cmark_parser *s_active_parser;
+#else
+  static cmark_parser *s_active_parser;
+#endif
+
+void cmark_streaming_set_active_parser(cmark_parser *p) {
+  s_active_parser = p;
+}
+
+cmark_parser *cmark_streaming_active_parser(void) {
+  return s_active_parser;
+}
+
+void cmark_streaming_state_init(struct cmark_parser_streaming_state *s) {
+  memset(s, 0, sizeof(*s));
+}
+
+static void free_event_chain(cmark_mem *mem,
+                              struct cmark_change_record *head) {
+  while (head) {
+    struct cmark_change_record *next = head->next;
+    mem->free(head);
+    head = next;
+  }
+}
+
+static void free_pending_refs(cmark_mem *mem,
+                              struct cmark_pending_ref_user *head) {
+  while (head) {
+    struct cmark_pending_ref_user *next = head->next;
+    cmark_chunk_free(mem, &head->label);
+    mem->free(head);
+    head = next;
+  }
+}
+
+void cmark_streaming_state_free(cmark_mem *mem,
+                                struct cmark_parser_streaming_state *s) {
+  free_event_chain(mem, s->events_head);
+  free_pending_refs(mem, s->pending_ref_users_head);
+  if (s->line_start_bytes) {
+    mem->free(s->line_start_bytes);
+  }
+  // The dirty-blocks list is intrusive into the node tree; clearing it does
+  // not require freeing per-node memory — the nodes themselves are owned by
+  // the document tree and freed via cmark_node_free.
+  memset(s, 0, sizeof(*s));
+}
+
+void cmark_streaming_record_line_start(cmark_parser *parser,
+                                       size_t byte_offset) {
+  struct cmark_parser_streaming_state *s = &parser->streaming;
+  if (s->line_start_bytes_len == s->line_start_bytes_cap) {
+    size_t new_cap = s->line_start_bytes_cap ? s->line_start_bytes_cap * 2 : 64;
+    size_t *resized = (size_t *)parser->mem->realloc(
+        s->line_start_bytes, new_cap * sizeof(size_t));
+    s->line_start_bytes = resized;
+    s->line_start_bytes_cap = new_cap;
+  }
+  s->line_start_bytes[s->line_start_bytes_len++] = byte_offset;
+}
+
+size_t cmark_streaming_byte_after_line(cmark_parser *parser, int line_number) {
+  struct cmark_parser_streaming_state *s = &parser->streaming;
+  if (line_number <= 0)
+    return 0;
+  // line k starts at line_start_bytes[k-1]; line k+1 starts at
+  // line_start_bytes[k]. So "byte after line k" = line_start_bytes[k].
+  if ((size_t)line_number < s->line_start_bytes_len) {
+    return s->line_start_bytes[line_number];
+  }
+  // Line k+1 has not been recorded yet. Either we're mid-line on line k+1
+  // (current_line_start_byte points to its start), or no further input has
+  // arrived. current_line_start_byte tracks the start of the line currently
+  // being assembled in linebuf, which is the next un-processed line.
+  if (s->current_line_start_byte > 0)
+    return s->current_line_start_byte;
+  return s->total_consumed_bytes;
+}
+
+void cmark_streaming_recompute_frontier(cmark_parser *parser) {
+  // Walk the document's first_child chain to find the longest committed-
+  // non-provisional prefix. To stay O(advance-since-last-call) instead of
+  // O(num-children) per line, we cache the last node we already attributed
+  // to the frontier and resume from its successor.
+  struct cmark_parser_streaming_state *s = &parser->streaming;
+  if (!parser->root) {
+    return;
+  }
+
+  cmark_node *last_committed = s->frontier_last_committed_child;
+  cmark_node *child = last_committed ? last_committed->next
+                                      : parser->root->first_child;
+  bool advanced = false;
+  cmark_node *blocker = NULL;
+
+  while (child) {
+    bool committed = !(child->flags & CMARK_NODE__OPEN) &&
+                     !(child->flags & CMARK_NODE__PROVISIONAL);
+    if (!committed) {
+      blocker = child;
+      break;
+    }
+    last_committed = child;
+    advanced = true;
+    child = child->next;
+  }
+
+  size_t new_frontier;
+  if (blocker) {
+    // Frontier ends just before the blocker's first byte.
+    if (blocker->start_line > 0 &&
+        (size_t)(blocker->start_line - 1) < s->line_start_bytes_len) {
+      new_frontier = s->line_start_bytes[blocker->start_line - 1];
+    } else if (last_committed) {
+      new_frontier = cmark_streaming_byte_after_line(parser,
+                                                     last_committed->end_line);
+    } else {
+      new_frontier = 0;
+    }
+  } else if (last_committed) {
+    new_frontier = cmark_streaming_byte_after_line(parser,
+                                                   last_committed->end_line);
+  } else {
+    new_frontier = 0;
+  }
+
+  if (advanced) {
+    s->frontier_last_committed_child = last_committed;
+  }
+  if (new_frontier > s->commit_frontier) {
+    s->commit_frontier = new_frontier;
+  }
+}
+
+// Mirror of contains_inlines() in blocks.c (which is static). Kept in sync
+// by hand — both must accept exactly the same set of block types.
+static bool streaming_contains_inlines(cmark_node *node) {
+  if (node->extension && node->extension->contains_inlines_func) {
+    return node->extension->contains_inlines_func(node->extension, node) != 0;
+  }
+  return (node->type == CMARK_NODE_PARAGRAPH ||
+          node->type == CMARK_NODE_HEADING);
+}
+
+static void free_block_children(cmark_node *block) {
+  while (block->first_child) {
+    // cmark_node_free unlinks from siblings/parent and frees subtree.
+    cmark_node_free(block->first_child);
+  }
+}
+
+void cmark_streaming_run_pending_inlines(cmark_parser *parser) {
+  cmark_node *block = cmark_streaming_drain_dirty_blocks(parser);
+  if (!block)
+    return;
+
+  // The inline parser consults extension special-character registries. We
+  // mirror process_inlines() in blocks.c by enabling them across the batch.
+  cmark_manage_extensions_special_characters(parser, true);
+
+  while (block) {
+    cmark_node *next = block->dirty_next;
+    block->dirty_next = NULL;
+    block->flags &= ~CMARK_NODE__INLINE_DIRTY;
+
+    // The block may have been freed (paragraph -> empty ref-def case). It
+    // may also have been morphed since it was marked dirty, in which case
+    // streaming_contains_inlines reflects the *current* type.
+    if (block->parent == NULL && block != parser->root) {
+      // Detached. Skip.
+      block = next;
+      continue;
+    }
+
+    if (streaming_contains_inlines(block)) {
+      free_block_children(block);
+      cmark_parse_inlines(parser, block, parser->refmap, parser->options);
+      block->inline_parsed_len = block->content.size;
+      cmark_streaming_record(parser, CMARK_CHANGE_NODE_INLINES_REPARSED,
+                             block);
+    } else {
+      // Non-inline-bearing block (CODE_BLOCK, HTML_BLOCK, custom literal
+      // extensions). Inline reparse is meaningless here — but the consumer
+      // still needs a signal that the block's raw content grew between
+      // snapshots, otherwise streamed code blocks render stale.
+      if (block->content.size > block->inline_parsed_len ||
+          block->inline_parsed_len == 0) {
+        cmark_streaming_record(parser, CMARK_CHANGE_NODE_CONTENT_UPDATED,
+                               block);
+      }
+      block->inline_parsed_len = block->content.size;
+    }
+
+    block = next;
+  }
+
+  cmark_manage_extensions_special_characters(parser, false);
+}
+
+void cmark_streaming_record(cmark_parser *parser, cmark_change_event event,
+                            cmark_node *node) {
+  struct cmark_change_record *rec =
+      (struct cmark_change_record *)parser->mem->calloc(
+          1, sizeof(struct cmark_change_record));
+  rec->event = event;
+  rec->node = node;
+  rec->next = NULL;
+
+  if (parser->streaming.events_tail) {
+    parser->streaming.events_tail->next = rec;
+  } else {
+    parser->streaming.events_head = rec;
+  }
+  parser->streaming.events_tail = rec;
+}
+
+void cmark_streaming_advance_consumed(cmark_parser *parser, size_t delta) {
+  parser->streaming.total_consumed_bytes += delta;
+}
+
+void cmark_streaming_mark_inline_dirty(cmark_parser *parser, cmark_node *block) {
+  if (!block || (block->flags & CMARK_NODE__INLINE_DIRTY))
+    return;
+  block->flags |= CMARK_NODE__INLINE_DIRTY;
+  block->dirty_next = parser->streaming.dirty_blocks_head;
+  parser->streaming.dirty_blocks_head = block;
+}
+
+cmark_node *cmark_streaming_drain_dirty_blocks(cmark_parser *parser) {
+  cmark_node *head = parser->streaming.dirty_blocks_head;
+  parser->streaming.dirty_blocks_head = NULL;
+  return head;
+}
+
+void cmark_streaming_set_provisional(cmark_parser *parser, cmark_node *node,
+                                     bool provisional) {
+  if (!node)
+    return;
+  bool was = (node->flags & CMARK_NODE__PROVISIONAL) != 0;
+  if (was == provisional)
+    return;
+  if (provisional) {
+    node->flags |= CMARK_NODE__PROVISIONAL;
+  } else {
+    node->flags &= ~CMARK_NODE__PROVISIONAL;
+    cmark_streaming_record(parser, CMARK_CHANGE_NODE_FINALIZED, node);
+  }
+}
+
+void cmark_node_morph(cmark_parser *parser, cmark_node *node,
+                      cmark_node_type new_type, bool clear_inline_dirty) {
+  if (!node || node->type == (uint16_t)new_type)
+    return;
+  // Route through cmark_node_set_type so the union is freed correctly and a
+  // RETYPED record is emitted (cmark_node_set_type consults the active
+  // parser via cmark_streaming_active_parser). We temporarily ensure
+  // `parser` is active in case the caller provided one we don't currently
+  // see — the typical caller is parsing-internal and this is already true,
+  // but doing it here makes the primitive safe to call from any context.
+  cmark_parser *prev = cmark_streaming_active_parser();
+  if (prev != parser)
+    cmark_streaming_set_active_parser(parser);
+  if (cmark_node_set_type(node, new_type) && clear_inline_dirty) {
+    node->flags &= ~CMARK_NODE__INLINE_DIRTY;
+    node->inline_parsed_len = 0;
+  }
+  if (prev != parser)
+    cmark_streaming_set_active_parser(prev);
+}
+
+void cmark_streaming_add_pending_ref(cmark_parser *parser,
+                                     cmark_chunk label,
+                                     cmark_node *block) {
+  struct cmark_pending_ref_user *u =
+      (struct cmark_pending_ref_user *)parser->mem->calloc(
+          1, sizeof(struct cmark_pending_ref_user));
+  // Take ownership of a copy of label so the original storage may be freed.
+  u->label.alloc = 1;
+  u->label.len = label.len;
+  u->label.data = (unsigned char *)parser->mem->calloc(1, (size_t)label.len + 1);
+  if (label.len > 0)
+    memcpy(u->label.data, label.data, label.len);
+  u->user_block = block;
+  u->next = parser->streaming.pending_ref_users_head;
+  parser->streaming.pending_ref_users_head = u;
+}
+
+void cmark_streaming_resolve_pending_refs(cmark_parser *parser,
+                                          cmark_chunk label) {
+  // CommonMark folds case and collapses whitespace when matching link labels.
+  // Compare normalized forms so [Foo Bar] resolves the def [foo  bar].
+  unsigned char *norm_resolved = normalize_map_label(parser->mem, &label);
+  if (norm_resolved == NULL)
+    return;
+  size_t norm_resolved_len = strlen((const char *)norm_resolved);
+
+  struct cmark_pending_ref_user **pp =
+      &parser->streaming.pending_ref_users_head;
+  while (*pp) {
+    struct cmark_pending_ref_user *u = *pp;
+    unsigned char *norm_pending =
+        normalize_map_label(parser->mem, &u->label);
+    bool match = false;
+    if (norm_pending) {
+      size_t l = strlen((const char *)norm_pending);
+      match = (l == norm_resolved_len) &&
+              (l == 0 ||
+               memcmp(norm_pending, norm_resolved, l) == 0);
+      parser->mem->free(norm_pending);
+    }
+    if (match) {
+      *pp = u->next;
+      cmark_streaming_mark_inline_dirty(parser, u->user_block);
+      cmark_chunk_free(parser->mem, &u->label);
+      parser->mem->free(u);
+    } else {
+      pp = &u->next;
+    }
+  }
+  parser->mem->free(norm_resolved);
+}
+
+// ------------------------------------------------------------------
+// Public API
+// ------------------------------------------------------------------
+
+int cmark_node_is_provisional(cmark_node *node) {
+  if (!node)
+    return 0;
+  return (node->flags & (CMARK_NODE__PROVISIONAL |
+                         CMARK_NODE__INLINE_PROVISIONAL)) ? 1 : 0;
+}
+
+cmark_node *cmark_parser_snapshot(cmark_parser *parser) {
+  // Drain the dirty-block list and re-parse inlines on each affected block,
+  // including those still open. Unclosed delimiters in an open block fall
+  // through the existing inline parser's cleanup path (last_delim /
+  // last_bracket pop) which converts them to literal text — the conservative
+  // interpretation. The block itself remains PROVISIONAL so consumers know
+  // the trailing content may yet shift.
+  cmark_parser *prev = cmark_streaming_active_parser();
+  cmark_streaming_set_active_parser(parser);
+  cmark_streaming_run_pending_inlines(parser);
+  cmark_streaming_set_active_parser(prev);
+
+  cmark_streaming_recompute_frontier(parser);
+  parser->streaming.snapshot_generation++;
+  return parser->root;
+}
+
+size_t cmark_parser_commit_frontier(cmark_parser *parser) {
+  return parser->streaming.commit_frontier;
+}
+
+cmark_change_iter *cmark_parser_changes_since_last_snapshot(
+    cmark_parser *parser) {
+  cmark_change_iter *iter =
+      (cmark_change_iter *)parser->mem->calloc(1, sizeof(*iter));
+  iter->mem = parser->mem;
+  iter->head = parser->streaming.events_head;
+  iter->to_free = parser->streaming.events_head;
+  // Detach the chain — caller is now responsible for it via _free.
+  parser->streaming.events_head = NULL;
+  parser->streaming.events_tail = NULL;
+  return iter;
+}
+
+cmark_change_event cmark_change_iter_next(cmark_change_iter *iter,
+                                         cmark_node **out_node) {
+  if (!iter || !iter->head) {
+    if (out_node)
+      *out_node = NULL;
+    return CMARK_CHANGE_NONE;
+  }
+  struct cmark_change_record *r = iter->head;
+  iter->head = r->next;
+  if (out_node)
+    *out_node = r->node;
+  return r->event;
+}
+
+void cmark_change_iter_free(cmark_change_iter *iter) {
+  if (!iter)
+    return;
+  cmark_mem *mem = iter->mem;
+  free_event_chain(mem, iter->to_free);
+  mem->free(iter);
+}

--- a/src/streaming.h
+++ b/src/streaming.h
@@ -1,0 +1,155 @@
+#ifndef CMARK_STREAMING_H
+#define CMARK_STREAMING_H
+
+#include "cmark-gfm.h"
+#include "node.h"
+#include "parser.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Internal change record. Public consumers walk these via cmark_change_iter
+ * declared in cmark-gfm.h.
+ */
+struct cmark_change_record {
+  /**
+   * Which kind of change this record describes. Determines how the `node`
+   * field below should be interpreted.
+   */
+  cmark_change_event event;
+  /**
+   * For NODE_ADDED / NODE_RETYPED / NODE_CONTENT_UPDATED /
+   * NODE_INLINES_REPARSED / NODE_FINALIZED: the affected node itself.
+   * For NODE_REMOVED: the parent of the removed node (the removed node
+   * pointer is no longer valid by the time the consumer sees the record).
+   */
+  cmark_node *node;
+  /**
+   * Singly-linked list pointer. Records are linked in chronological order
+   * of emission; the head is the oldest unread record.
+   */
+  struct cmark_change_record *next;
+};
+
+/**
+ * Initialize/free per-parser streaming state. Called by cmark_parser_reset
+ * and cmark_parser_dispose.
+ */
+void cmark_streaming_state_init(struct cmark_parser_streaming_state *s);
+void cmark_streaming_state_free(cmark_mem *mem,
+                                struct cmark_parser_streaming_state *s);
+
+/**
+ * Set/get the parser that is currently consuming input on this thread.
+ * Used so that mutation primitives like cmark_node_set_type can emit
+ * change events without taking the parser as a parameter (which would
+ * change public ABIs). NULL when no parser is active.
+ *
+ * Implemented as a thread-local: each thread may drive its own parser.
+ */
+void cmark_streaming_set_active_parser(cmark_parser *p);
+cmark_parser *cmark_streaming_active_parser(void);
+
+/**
+ * Append `byte_offset` to the parser's line->byte map. Called by
+ * S_parser_feed at the moment a line is about to be processed. The k-th
+ * call (0-indexed) records the start byte of line k+1.
+ */
+void cmark_streaming_record_line_start(cmark_parser *parser,
+                                       size_t byte_offset);
+
+/**
+ * Returns the byte offset just after the end of `line_number` (1-indexed) —
+ * i.e. the byte where line (line_number + 1) starts, or the byte offset of
+ * the in-progress line if line_number+1 has not yet been processed, or
+ * total_consumed_bytes if no further input has been observed.
+ */
+size_t cmark_streaming_byte_after_line(cmark_parser *parser, int line_number);
+
+/**
+ * Recompute parser->streaming.commit_frontier by scanning the document's
+ * children for the longest committed-non-provisional prefix. Idempotent.
+ */
+void cmark_streaming_recompute_frontier(cmark_parser *parser);
+
+/**
+ * Drain the dirty-block list, running incremental inline parsing on each
+ * block whose `contains_inlines` predicate is true. For each such block:
+ *   - existing inline children are freed,
+ *   - cmark_parse_inlines is called against the block's content + refmap,
+ *   - INLINE_DIRTY is cleared, inline_parsed_len is updated to content size,
+ *   - a CMARK_CHANGE_NODE_INLINES_REPARSED record is emitted.
+ *
+ * Called by cmark_parser_snapshot. The same machinery also handles the
+ * finalize-time pass — process_inlines() in blocks.c routes through here so
+ * a tree that has already been incrementally parsed is not re-parsed.
+ */
+void cmark_streaming_run_pending_inlines(cmark_parser *parser);
+
+/**
+ * Record an event in the streaming event stream. node may be NULL for
+ * NODE_REMOVED if no parent is meaningful (top-level removal). Allocates
+ * from parser->mem.
+ */
+void cmark_streaming_record(cmark_parser *parser, cmark_change_event event,
+                            cmark_node *node);
+
+/**
+ * Advance total_consumed_bytes by `delta`. Called from S_parser_feed.
+ */
+void cmark_streaming_advance_consumed(cmark_parser *parser, size_t delta);
+
+/**
+ * Mark a block's inline content as dirty, queuing it for re-parse on the
+ * next snapshot. Idempotent.
+ */
+void cmark_streaming_mark_inline_dirty(cmark_parser *parser, cmark_node *block);
+
+/**
+ * Drain the dirty-block list. Returns the head; caller must walk via
+ * dirty_next and reset each node's CMARK_NODE__INLINE_DIRTY flag and
+ * dirty_next pointer.
+ */
+cmark_node *cmark_streaming_drain_dirty_blocks(cmark_parser *parser);
+
+/**
+ * Set/clear the provisional flag on a node, emitting a NODE_FINALIZED event
+ * when clearing.
+ */
+void cmark_streaming_set_provisional(cmark_parser *parser, cmark_node *node,
+                                     bool provisional);
+
+/**
+ * In-place node rewrite. Replaces `node->type` (and optionally its `as`
+ * payload) without changing the node's pointer identity, parent, or sibling
+ * links. Children may be edited by the caller before/after; this primitive
+ * does not touch them. The node's flags are preserved except as noted by
+ * `clear_inline_dirty` (set it to true to drop any pending inline state when
+ * the new type does not contain inlines).
+ *
+ * Emits a CMARK_CHANGE_NODE_RETYPED record.
+ */
+void cmark_node_morph(cmark_parser *parser, cmark_node *node,
+                      cmark_node_type new_type, bool clear_inline_dirty);
+
+/**
+ * Add a pending [ref] user — when `block` contains an unresolved reference
+ * of `label`, the block must be re-inline-parsed once the definition arrives.
+ */
+void cmark_streaming_add_pending_ref(cmark_parser *parser,
+                                     cmark_chunk label,
+                                     cmark_node *block);
+/**
+ * Notify that a definition for `label` has arrived. All pending users are
+ * removed and marked inline-dirty.
+ */
+void cmark_streaming_resolve_pending_refs(cmark_parser *parser,
+                                          cmark_chunk label);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
cmark_parser_snapshot() returns the current AST between feed() calls; the result converges to one-shot parse(prefix) semantics. The trailing portion may be rewritten in place (paragraph->setext heading, paragraph->table head, unmatched-emph->EMPH, [foo]->link upon ref-def arrival) with pointer identity preserved across morph; the prefix before commit_frontier is final.

New public API in cmark-gfm.h:
  - cmark_parser_snapshot()
  - cmark_parser_commit_frontier()
  - cmark_parser_changes_since_last_snapshot() + cmark_change_iter
  - cmark_node_is_provisional()
  - cmark_change_event enum (NODE_ADDED/REMOVED/RETYPED/CONTENT_UPDATED/ INLINES_REPARSED/FINALIZED)

Internals:
  - In-place node morph via cmark_node_set_type, with children incompatible with the new type freed automatically
  - Per-block PROVISIONAL flag; NODE_FINALIZED event on close
  - Byte-level commit frontier with line->byte map; O(advance) walk via cached last-committed child
  - Incremental inline parse on snapshot; INLINE_PROVISIONAL flag on unmatched delimiters in still-open blocks
  - Pending-ref reverse index: [foo] uses register against unresolved labels; cmark_reference_create resolves them and marks user blocks dirty; refmap sorted-cache invalidated on add
  - Eager ref-def extraction in add_line with title-continuation safety check (defer if next byte is whitespace)
  - Thread-local active parser so set_type and reference_create emit change events without ABI changes to those functions

Validated by byte-by-byte differential tests on 18 representative inputs (plain + GFM): streamed parse with snapshot-after-every-byte produces byte-identical HTML to cmark_parse_document. ABI: cmark_node gains inline_parsed_len + dirty_next; cmark_parser embeds streaming sub-struct. All 13 existing ctest still pass (spec, roundtrip, regression, extensions, pathological).