### PR TITLE
🔧 Add config.cmake and config-version.cmake files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ set(PROJECT_VERSION_PATCH 0)
 set(PROJECT_VERSION_GFM 13)
 set(PROJECT_VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}.gfm.${PROJECT_VERSION_GFM})
 
+include(CMakePackageConfigHelpers)
 include("FindAsan.cmake")
 include("CheckFileOffsetBits.cmake")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 4.0)
 project(cmark-gfm)
 
 set(PROJECT_VERSION_MAJOR 0)

--- a/extensions/CMakeLists.txt
+++ b/extensions/CMakeLists.txt
@@ -85,6 +85,25 @@ if (CMARK_SHARED OR CMARK_STATIC)
   )
 endif()
 
+# generate config and config-version files
+configure_package_config_file(
+  "cmark-gfm-extensions-config.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/generated/cmark-gfm-extensions-config.cmake"
+  INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/cmark-gfm-extensions"
+)
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/generated/cmark-gfm-extensions-config-version.cmake"
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY SameMajorVersion
+)
+
+# install config and config-version files
+install(
+  FILES "${CMAKE_CURRENT_BINARY_DIR}/generated/cmark-gfm-extensions-config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/generated/cmark-gfm-extensions-config-version.cmake"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/cmark-gfm-extensions"
+)
+
 # Feature tests
 include(CheckIncludeFile)
 include(CheckCSourceCompiles)

--- a/extensions/CMakeLists.txt
+++ b/extensions/CMakeLists.txt
@@ -79,7 +79,10 @@ if (CMARK_SHARED OR CMARK_STATIC)
   DESTINATION include
   )
 
-  install(EXPORT cmark-gfm-extensions DESTINATION lib${LIB_SUFFIX}/cmake-gfm-extensions)
+  install(
+    EXPORT cmark-gfm-extensions
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/cmark-gfm-extensions"
+  )
 endif()
 
 # Feature tests

--- a/extensions/cmark-gfm-extensions-config.cmake.in
+++ b/extensions/cmark-gfm-extensions-config.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/cmark-gfm-extensions.cmake")
+check_required_components("cmark-gfm-extensions")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -181,6 +181,25 @@ if(CMARK_SHARED OR CMARK_STATIC)
   )
 endif()
 
+# generate config and config-version files
+configure_package_config_file(
+  "cmark-gfm-config.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/generated/cmark-gfm-config.cmake"
+  INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/cmark-gfm"
+)
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/generated/cmark-gfm-config-version.cmake"
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY SameMajorVersion
+)
+
+# install config and config-version files
+install(
+  FILES "${CMAKE_CURRENT_BINARY_DIR}/generated/cmark-gfm-config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/generated/cmark-gfm-config-version.cmake"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/cmark-gfm"
+)
+
 # Feature tests
 include(CheckIncludeFile)
 include(CheckCSourceCompiles)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -175,7 +175,10 @@ if(CMARK_SHARED OR CMARK_STATIC)
     DESTINATION include
     )
 
-  install(EXPORT cmark-gfm DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
+  install(
+    EXPORT cmark-gfm
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/cmark-gfm"
+  )
 endif()
 
 # Feature tests

--- a/src/cmark-gfm-config.cmake.in
+++ b/src/cmark-gfm-config.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/cmark-gfm.cmake")
+check_required_components("cmark-gfm")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,9 +4,9 @@
 # To require the spec tests, compile with -DSPEC_TESTS=1
 
 if (SPEC_TESTS)
-  find_package(PythonInterp 3 REQUIRED)
+  find_package(Python 3 COMPONENTS Interpreter REQUIRED)
 else(SPEC_TESTS)
-  find_package(PythonInterp 3)
+  find_package(Python 3 COMPONENTS Interpreter)
 endif(SPEC_TESTS)
 
 if (CMARK_SHARED OR CMARK_STATIC)
@@ -24,48 +24,48 @@ else(WIN32)
   set(ROUNDTRIP "${CMAKE_CURRENT_SOURCE_DIR}/roundtrip.sh")
 endif(WIN32)
 
-IF (PYTHONINTERP_FOUND)
+if(Python_Interpreter_FOUND)
 
   add_test(html_normalization
-    ${PYTHON_EXECUTABLE} "-m" "doctest"
+    ${Python_EXECUTABLE} "-m" "doctest"
     "${CMAKE_CURRENT_SOURCE_DIR}/normalize.py"
     )
 
   if (CMARK_SHARED)
     add_test(spectest_library
-      ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py" "--no-normalize" "--spec"
+      ${Python_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py" "--no-normalize" "--spec"
       "${CMAKE_CURRENT_SOURCE_DIR}/spec.txt" "--library-dir" "${CMAKE_CURRENT_BINARY_DIR}/../src"
       )
 
     add_test(pathological_tests_library
-      ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/pathological_tests.py"
+      ${Python_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/pathological_tests.py"
       "--library-dir" "${CMAKE_CURRENT_BINARY_DIR}/../src"
       )
 
     add_test(roundtriptest_library
-      ${PYTHON_EXECUTABLE}
+      ${Python_EXECUTABLE}
       "${CMAKE_CURRENT_SOURCE_DIR}/roundtrip_tests.py"
       "--spec" "${CMAKE_CURRENT_SOURCE_DIR}/spec.txt"
       "--library-dir" "${CMAKE_CURRENT_BINARY_DIR}/../src"
       )
 
     add_test(entity_library
-      ${PYTHON_EXECUTABLE}
+      ${Python_EXECUTABLE}
       "${CMAKE_CURRENT_SOURCE_DIR}/entity_tests.py"
       "--library-dir" "${CMAKE_CURRENT_BINARY_DIR}/../src"
       )
   endif()
 
   add_test(spectest_executable
-    ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py" "--no-normalize" "--spec" "${CMAKE_CURRENT_SOURCE_DIR}/spec.txt" "--program" "${CMAKE_CURRENT_BINARY_DIR}/../src/cmark-gfm"
+    ${Python_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py" "--no-normalize" "--spec" "${CMAKE_CURRENT_SOURCE_DIR}/spec.txt" "--program" "${CMAKE_CURRENT_BINARY_DIR}/../src/cmark-gfm"
     )
 
   add_test(smartpuncttest_executable
-    ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py" "--no-normalize" "--spec" "${CMAKE_CURRENT_SOURCE_DIR}/smart_punct.txt" "--program" "${CMAKE_CURRENT_BINARY_DIR}/../src/cmark-gfm --smart"
+    ${Python_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py" "--no-normalize" "--spec" "${CMAKE_CURRENT_SOURCE_DIR}/smart_punct.txt" "--program" "${CMAKE_CURRENT_BINARY_DIR}/../src/cmark-gfm --smart"
     )
 
   add_test(extensions_executable
-    ${PYTHON_EXECUTABLE}
+    ${Python_EXECUTABLE}
     "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py"
     "--no-normalize"
     "--spec" "${CMAKE_CURRENT_SOURCE_DIR}/extensions.txt"
@@ -74,7 +74,7 @@ IF (PYTHONINTERP_FOUND)
     )
 
   add_test(roundtrip_extensions_executable
-    ${PYTHON_EXECUTABLE}
+    ${Python_EXECUTABLE}
     "${CMAKE_CURRENT_SOURCE_DIR}/roundtrip_tests.py"
     "--spec" "${CMAKE_CURRENT_SOURCE_DIR}/extensions.txt"
     "--program" "${CMAKE_CURRENT_BINARY_DIR}/../src/cmark-gfm"
@@ -82,7 +82,7 @@ IF (PYTHONINTERP_FOUND)
     )
 
   add_test(option_table_prefer_style_attributes
-    ${PYTHON_EXECUTABLE}
+    ${Python_EXECUTABLE}
     "${CMAKE_CURRENT_SOURCE_DIR}/roundtrip_tests.py"
     "--spec" "${CMAKE_CURRENT_SOURCE_DIR}/extensions-table-prefer-style-attributes.txt"
     "--program" "${CMAKE_CURRENT_BINARY_DIR}/../src/cmark-gfm --table-prefer-style-attributes"
@@ -90,25 +90,24 @@ IF (PYTHONINTERP_FOUND)
     )
 
   add_test(option_full_info_string
-    ${PYTHON_EXECUTABLE}
+    ${Python_EXECUTABLE}
     "${CMAKE_CURRENT_SOURCE_DIR}/roundtrip_tests.py"
     "--spec" "${CMAKE_CURRENT_SOURCE_DIR}/extensions-full-info-string.txt"
     "--program" "${CMAKE_CURRENT_BINARY_DIR}/../src/cmark-gfm --full-info-string"
     )
 
   add_test(regressiontest_executable
-    ${PYTHON_EXECUTABLE}
+    ${Python_EXECUTABLE}
     "${CMAKE_CURRENT_SOURCE_DIR}/spec_tests.py" "--no-normalize" "--spec"
     "${CMAKE_CURRENT_SOURCE_DIR}/regression.txt" "--program"
     "${CMAKE_CURRENT_BINARY_DIR}/../src/cmark-gfm"
     )
 
 
-ELSE(PYTHONINTERP_FOUND)
+else(Python_Interpreter_FOUND)
 
   message("\n*** A python 3 interpreter is required to run the spec tests.\n")
   add_test(skipping_spectests
     echo "Skipping spec tests, because no python 3 interpreter is available.")
 
-ENDIF(PYTHONINTERP_FOUND)
-
+endif(Python_Interpreter_FOUND)


### PR DESCRIPTION
_Hello everyone,_

**Telegram Desktop** devs [have introduced](https://github.com/telegramdesktop/tdesktop/releases/tag/v6.9.0) mandatory Markdown support based on **cmark-gfm**.
In order to properly package and build it on [Gentoo Linux](https://www.gentoo.org), some adjustments are needed.

These changes are based on:
  - https://github.com/commonmark/cmark/commit/853cf7c9 by @compnerd
  - [cmake-minimum-required.patch](https://gitweb.gentoo.org/repo/proj/guru.git/commit/app-text/cmark-gfm/files/cmake-minimum-required.patch?id=24b13f11) by @yamader

_Best regards!_

_P.S. I see this repo is abandoned, but still I'd like to submit this PR for the sake of transparency._